### PR TITLE
Switch K8s registry to registry.k8s.io

### DIFF
--- a/pkg/k8sclient/manifests/metrics-server/metrics-server-deployment.yaml
+++ b/pkg/k8sclient/manifests/metrics-server/metrics-server-deployment.yaml
@@ -45,7 +45,7 @@ spec:
         emptyDir: {}
       containers:
       - name: metrics-server
-        image: k8s.gcr.io/metrics-server-amd64:v0.3.5
+        image: registry.k8s.io/metrics-server-amd64:v0.3.5
         imagePullPolicy: Always
         volumeMounts:
         - name: tmp-dir


### PR DESCRIPTION
# Description
Update K8s image registry to registry.k8s.io. Validated that the images we use exist in the new registry.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|[744](https://github.com/dell/csm/issues/744)|

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Manual pull of Docker image.
