### PR TITLE
Statically linking glibc while building standalone binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,15 +40,15 @@ gocover:
 	go tool cover -html=c.out
 
 build:
-	go build -ldflags "-s -w" ./cmd/cert-csi
+	CGO_ENABLED=0 go build ./cmd/cert-csi
 
 install-nix:
-	go build -ldflags "-s -w" ./cmd/cert-csi
+	CGO_ENABLED=0 go build ./cmd/cert-csi
 	./autocomplete.sh
 
 distribute:
-	GOOS=windows GOARCH=amd64 go build -o build/cert-csi.exe -ldflags "-s -w" ./cmd/cert-csi
-	GOOS=linux GOARCH=amd64 go build -o build/cert-csi -ldflags "-s -w" ./cmd/cert-csi
+	GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -o build/cert-csi.exe ./cmd/cert-csi
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o build/cert-csi ./cmd/cert-csi
 
 install-ms:
 	kubectl create -f ./pkg/k8sclient/manifests/metrics-server

--- a/Makefile
+++ b/Makefile
@@ -40,15 +40,20 @@ gocover:
 	go tool cover -html=c.out
 
 build:
-	CGO_ENABLED=0 go build ./cmd/cert-csi
+	go build -ldflags "-s -w" ./cmd/cert-csi
+
+# build-statically-linked : used for building a standalone binary with statically linked glibc
+# this command should be used when building the binary for distributing it to customer/user
+build-statically-linked:
+	CGO_ENABLED=1 CGO_LDFLAGS="-static" go build ./cmd/cert-csi
 
 install-nix:
-	CGO_ENABLED=0 go build ./cmd/cert-csi
+	go build -ldflags "-s -w" ./cmd/cert-csi
 	./autocomplete.sh
 
 distribute:
-	GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -o build/cert-csi.exe ./cmd/cert-csi
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o build/cert-csi ./cmd/cert-csi
+	GOOS=windows GOARCH=amd64 go build -o build/cert-csi.exe -ldflags "-s -w" ./cmd/cert-csi
+	GOOS=linux GOARCH=amd64 go build -o build/cert-csi -ldflags "-s -w" ./cmd/cert-csi
 
 install-ms:
 	kubectl create -f ./pkg/k8sclient/manifests/metrics-server


### PR DESCRIPTION
# Description
Statically linking glibc while building standalone binary

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/827 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Ran cert-csi binary, where it was not working before i.e. setup where glibc version (ldd --version) were different.

- [x] Ran cert-csi against CSI-PowerStore driver and all suites passed as per the expectation.
![image](https://github.com/dell/cert-csi/assets/109620911/2768d668-de82-4d5b-be1b-47f4c7e3bc44)
![image](https://github.com/dell/cert-csi/assets/109620911/b236d885-4c09-4ffa-893a-a6c5d002aa54)

- [x] Ran ldd ./cert-csi to check if binary is statically linked or not.
![image](https://github.com/dell/cert-csi/assets/109620911/e6ec8bd7-ee94-4729-a2d6-fd2a5bc35598)

