### PR TITLE
Fixed the --attr format for Ephemeral test suite

### DIFF
--- a/pkg/cmd/testcmd.go
+++ b/pkg/cmd/testcmd.go
@@ -22,7 +22,6 @@ import (
 	"cert-csi/pkg/testcore/runner"
 	"cert-csi/pkg/testcore/suites"
 	"fmt"
-	"strings"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -934,9 +933,9 @@ func getEphemeralCreationCommand(globalFlags []cli.Flag) cli.Command {
 					Name:  "pod-name, pname",
 					Usage: "custom name for pod and cloned volume pod to create",
 				},
-				cli.StringSliceFlag{
-					Name:     "volumeAttributes, attr",
-					Usage:    "CSI attributes for volume. Could be several.",
+				cli.StringFlag{
+					Name:     "csi-attributes, attr",
+					Usage:    "CSI attributes properties file for the ephemeral volume",
 					Required: true,
 				},
 			},
@@ -948,16 +947,12 @@ func getEphemeralCreationCommand(globalFlags []cli.Flag) cli.Command {
 			desc := c.String("description")
 			fsType := c.String("fs-type")
 			podName := c.String("pod-name")
-			attr := c.StringSlice("attr")
+			attributesFile := c.String("csi-attributes")
 
-			var volAttributes = map[string]string{}
-
-			for _, param := range attr {
-				values := strings.Split(param, "=")
-				if len(values) != 2 {
-					log.Errorf("Parameter %s incorrect.", param)
-				}
-				volAttributes[values[0]] = values[1]
+			// We will generate volumeAttributes by reading the properties file
+			volAttributes, err := readEphemeralConfig(attributesFile)
+			if err != nil {
+				return err
 			}
 			log.Debugf("Volume Attributes:%+v", volAttributes)
 


### PR DESCRIPTION
# Description
Fixed the arg --attr format for ephemeral test suite to keep args format same for both functional and performance suite.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/930|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Run ephemeral test suite by passing fileName as a value to the --attr args and the suites passes as per the expectation. 
./cert-csi test ephemeral-volume --driver csi-powerstore.dellem          c.com --fs-type ext4 --attr attr-file --pods 5 --pod-name wrephe
![image](https://github.com/dell/cert-csi/assets/109620911/d37ec76a-d133-4233-b122-7570f2ab73d9)

