### PR TITLE
Metrics client was missing in VGS suite

### DIFF
--- a/pkg/testcore/suites/perf-suites.go
+++ b/pkg/testcore/suites/perf-suites.go
@@ -1267,12 +1267,18 @@ func (vgs *VolumeGroupSnapSuite) GetClients(namespace string, client *k8sclient.
 	if vaErr != nil {
 		return nil, vaErr
 	}
-
+	
+	metricsClient, mcErr := client.CreateMetricsClient(namespace)
+	if mcErr != nil {
+		return nil, mcErr
+	}
+		
 	return &k8sclient.Clients{
 		PVCClient: pvcClient,
 		PodClient: podClient,
 		VaClient:  vaClient,
 		VgsClient: vgsClient,
+		MetricsClient: metricsClient,
 	}, nil
 }
 

--- a/pkg/testcore/suites/perf-suites.go
+++ b/pkg/testcore/suites/perf-suites.go
@@ -1267,17 +1267,17 @@ func (vgs *VolumeGroupSnapSuite) GetClients(namespace string, client *k8sclient.
 	if vaErr != nil {
 		return nil, vaErr
 	}
-	
+
 	metricsClient, mcErr := client.CreateMetricsClient(namespace)
 	if mcErr != nil {
 		return nil, mcErr
 	}
-		
+
 	return &k8sclient.Clients{
-		PVCClient: pvcClient,
-		PodClient: podClient,
-		VaClient:  vaClient,
-		VgsClient: vgsClient,
+		PVCClient:     pvcClient,
+		PodClient:     podClient,
+		VaClient:      vaClient,
+		VgsClient:     vgsClient,
 		MetricsClient: metricsClient,
 	}, nil
 }


### PR DESCRIPTION
# Description
Added Metrics client in VGS suite that was causing panic when user was trying to run vgs suite with metrics enabled and was passing --namespace flag.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/931|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Ran VGS suite and enabled metrics and passed --namespace/--ns flag with it's value and it worked well, i.e. no panic is seen.
