### PR TITLE
k8s 1.28.0 e2e support

### DIFF
--- a/pkg/utils/k8s_utils.go
+++ b/pkg/utils/k8s_utils.go
@@ -162,6 +162,8 @@ func GetURL(version string) (string, error) {
 		return BinaryPrefix + version + BinarySuffix, nil
 	case "v1.27.0":
 		return BinaryPrefix + version + BinarySuffix, nil
+        case "v1.28.0":
+                return BinaryPrefix + version + BinarySuffix, nil
 	default:
 		return "", errors.New("Unable to build URL with the given version:" + version)
 	}


### PR DESCRIPTION
# Description
Enable kubernetes e2e test suit for 1.28.0 

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/885|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Built cert csi binary and tested e2e suit with k8s-1.28.0 - Success
  
  
![image](https://github.com/dell/cert-csi/assets/90749010/bea9cc81-0df6-4fab-8bd7-fb7d6a3f364e)

![image](https://github.com/dell/cert-csi/assets/90749010/e6b9384a-7396-40dc-bf6b-b59d66a88b23)

