### PR TITLE
[feature-1012]: Always run VolumeIO suite in ceritfy

### DIFF
--- a/pkg/cmd/certifycmd.go
+++ b/pkg/cmd/certifycmd.go
@@ -207,6 +207,13 @@ func GetCertifyCommand() cli.Command {
 					minSize = sc.MinSize
 				}
 
+				s = append(s, &suites.VolumeIoSuite{
+					VolumeNumber: 2,
+					VolumeSize:   minSize,
+					ChainNumber:  2,
+					ChainLength:  2,
+				})
+
 				s = append(s, &suites.ScalingSuite{
 					ReplicaNumber:    2,
 					VolumeNumber:     5,
@@ -222,12 +229,6 @@ func GetCertifyCommand() cli.Command {
 						VolumeSize:   minSize,
 					})
 
-					s = append(s, &suites.VolumeIoSuite{
-						VolumeNumber: 2,
-						VolumeSize:   minSize,
-						ChainNumber:  2,
-						ChainLength:  2,
-					})
 				}
 
 				if sc.Expansion {


### PR DESCRIPTION
# Description
The VolumeIO suite only gets executed in `certify` if cloning is enabled. It should always be executed.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1012 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

```
# make test
(go test -race -v -coverprofile=c.out ./...)
?       github.com/dell/cert-csi/cmd/cert-csi   [no test files]
?       github.com/dell/cert-csi/pkg/cmd        [no test files]
?       github.com/dell/cert-csi/pkg/helm       [no test files]
=== RUN   TestCollectorTestSuite
=== RUN   TestCollectorTestSuite/TestCollectMetrics
Collecting metrics
1 / 1 [---------------------------------------------------------------------------------------------------------------------------------------------------------] 100.00% ? p/s--- PASS: TestCollectorTestSuite (0.04s)
    --- PASS: TestCollectorTestSuite/TestCollectMetrics (0.00s)
PASS
coverage: 70.5% of statements
ok      github.com/dell/cert-csi/pkg/collector  1.091s  coverage: 70.5% of statements
?       github.com/dell/cert-csi/pkg/k8sclient/resources/commonparams   [no test files]
?       github.com/dell/cert-csi/pkg/k8sclient/resources/csistoragecapacity     [no test files]
?       github.com/dell/cert-csi/pkg/k8sclient/resources/metrics        [no test files]
?       github.com/dell/cert-csi/pkg/k8sclient/resources/node   [no test files]
=== RUN   TestCoreTestSuite
=== RUN   TestCoreTestSuite/TestCreateClients
=== RUN   TestCoreTestSuite/TestCreateClients/pvc_client
=== RUN   TestCoreTestSuite/TestCreateClients/pod_client
=== RUN   TestCoreTestSuite/TestCreateClients/va_client
=== RUN   TestCoreTestSuite/TestCreateClients/sts_client
=== RUN   TestCoreTestSuite/TestCreateClients/m_client
=== RUN   TestCoreTestSuite/TestCreateNamespace
=== RUN   TestCoreTestSuite/TestCreateNamespace/create_empty
time="2023-11-16T15:32:21-05:00" level=info msg="Successfully created namespace "
=== RUN   TestCoreTestSuite/TestCreateNamespace/create_test_namespace
time="2023-11-16T15:32:21-05:00" level=info msg="Successfully created namespace test-namespace"
=== RUN   TestCoreTestSuite/TestCreateNamespace/create_error
time="2023-11-16T15:32:21-05:00" level=error msg="Unexpected error: Can't create namespace"
=== RUN   TestCoreTestSuite/TestCreateNamespace/create_with_suffix
time="2023-11-16T15:32:21-05:00" level=info msg="Successfully created namespace test-namespace-228c6aea"
=== RUN   TestCoreTestSuite/TestDeleteNamespace
time="2023-11-16T15:32:21-05:00" level=info msg="Successfully created namespace test-namespace"
time="2023-11-16T15:32:21-05:00" level=info msg="Namespace test-namespace was deleted in 197.077µs"
=== RUN   TestCoreTestSuite/TestGetConfig
time="2023-11-16T15:32:21-05:00" level=info msg="Using config from testdata/config"
time="2023-11-16T15:32:21-05:00" level=info msg="Successfully loaded config. Host: https://192.168.0.1:6443"
time="2023-11-16T15:32:21-05:00" level=info msg="Using config from /non/existing/path"
time="2023-11-16T15:32:21-05:00" level=error msg="Can't load config at \"/non/existing/path\", error = stat /non/existing/path: no such file or directory"
=== RUN   TestCoreTestSuite/TestNamespaceExists
time="2023-11-16T15:32:21-05:00" level=info msg="Successfully created namespace test-namespace"
=== RUN   TestCoreTestSuite/TestNewKubeClient
=== RUN   TestCoreTestSuite/TestNewKubeClient/nil_config
=== RUN   TestCoreTestSuite/TestNewKubeClient/empty_config
time="2023-11-16T15:32:21-05:00" level=info msg="Created new KubeClient"
=== RUN   TestCoreTestSuite/TestNewKubeClient/incorrect_config
=== RUN   TestCoreTestSuite/TestStorageExists
--- PASS: TestCoreTestSuite (0.03s)
    --- PASS: TestCoreTestSuite/TestCreateClients (0.00s)
        --- PASS: TestCoreTestSuite/TestCreateClients/pvc_client (0.00s)
        --- PASS: TestCoreTestSuite/TestCreateClients/pod_client (0.00s)
        --- PASS: TestCoreTestSuite/TestCreateClients/va_client (0.00s)
        --- PASS: TestCoreTestSuite/TestCreateClients/sts_client (0.00s)
        --- PASS: TestCoreTestSuite/TestCreateClients/m_client (0.00s)
    --- PASS: TestCoreTestSuite/TestCreateNamespace (0.00s)
        --- PASS: TestCoreTestSuite/TestCreateNamespace/create_empty (0.00s)
        --- PASS: TestCoreTestSuite/TestCreateNamespace/create_test_namespace (0.00s)
        --- PASS: TestCoreTestSuite/TestCreateNamespace/create_error (0.00s)
        --- PASS: TestCoreTestSuite/TestCreateNamespace/create_with_suffix (0.00s)
    --- PASS: TestCoreTestSuite/TestDeleteNamespace (0.00s)
    --- PASS: TestCoreTestSuite/TestGetConfig (0.01s)
    --- PASS: TestCoreTestSuite/TestNamespaceExists (0.00s)
    --- PASS: TestCoreTestSuite/TestNewKubeClient (0.00s)
        --- PASS: TestCoreTestSuite/TestNewKubeClient/nil_config (0.00s)
        --- PASS: TestCoreTestSuite/TestNewKubeClient/empty_config (0.00s)
        --- PASS: TestCoreTestSuite/TestNewKubeClient/incorrect_config (0.00s)
    --- PASS: TestCoreTestSuite/TestStorageExists (0.00s)
PASS
coverage: 39.2% of statements
ok      github.com/dell/cert-csi/pkg/k8sclient  1.184s  coverage: 39.2% of statements
?       github.com/dell/cert-csi/pkg/k8sclient/resources/pv     [no test files]
?       github.com/dell/cert-csi/pkg/k8sclient/resources/pvc    [no test files]
?       github.com/dell/cert-csi/pkg/k8sclient/resources/replicationgroup       [no test files]
?       github.com/dell/cert-csi/pkg/k8sclient/resources/sc     [no test files]
?       github.com/dell/cert-csi/pkg/k8sclient/resources/statefulset    [no test files]
=== RUN   TestPodTestSuite
=== RUN   TestPodTestSuite/TestCreatePod
=== RUN   TestPodTestSuite/TestCreatePod/nil_pod_object
=== RUN   TestPodTestSuite/TestCreatePod/empty_pod_object
=== RUN   TestPodTestSuite/TestCreatePod/simple_pod_object
=== RUN   TestPodTestSuite/TestMakePod
=== RUN   TestPodTestSuite/TestMakePod_default
--- PASS: TestPodTestSuite (0.02s)
    --- PASS: TestPodTestSuite/TestCreatePod (0.00s)
        --- PASS: TestPodTestSuite/TestCreatePod/nil_pod_object (0.00s)
        --- PASS: TestPodTestSuite/TestCreatePod/empty_pod_object (0.00s)
        --- PASS: TestPodTestSuite/TestCreatePod/simple_pod_object (0.00s)
    --- PASS: TestPodTestSuite/TestMakePod (0.00s)
    --- PASS: TestPodTestSuite/TestMakePod_default (0.00s)
PASS
coverage: 12.5% of statements
ok      github.com/dell/cert-csi/pkg/k8sclient/resources/pod    1.155s  coverage: 12.5% of statements
?       github.com/dell/cert-csi/pkg/k8sclient/resources/volumegroupsnapshot    [no test files]
?       github.com/dell/cert-csi/pkg/k8sclient/resources/volumesnapshot [no test files]
?       github.com/dell/cert-csi/pkg/k8sclient/resources/volumesnapshot/v1      [no test files]
?       github.com/dell/cert-csi/pkg/k8sclient/resources/volumesnapshot/v1beta1 [no test files]
?       github.com/dell/cert-csi/pkg/k8sclient/resources/volumesnapshotcontent/v1       [no test files]
?       github.com/dell/cert-csi/pkg/k8sclient/resources/volumesnapshotcontent/v1beta1  [no test files]
?       github.com/dell/cert-csi/pkg/observer   [no test files]
=== RUN   TestVaTestSuite
=== RUN   TestVaTestSuite/TestVaClient_WaitUntilNoneLeft
=== RUN   TestVaTestSuite/TestVaClient_WaitUntilNoneLeft/timeout_error
time="2023-11-16T15:32:39-05:00" level=info msg="Waiting until no Volume Attachments left in test-namespace"
=== RUN   TestVaTestSuite/TestVaClient_WaitUntilNoneLeft/all_deleted
time="2023-11-16T15:32:40-05:00" level=info msg="Waiting until no Volume Attachments left in test-namespace"
time="2023-11-16T15:32:40-05:00" level=info msg="All VolumeAttachments deleted in test-namespace namespace"
--- PASS: TestVaTestSuite (1.01s)
    --- PASS: TestVaTestSuite/TestVaClient_WaitUntilNoneLeft (1.00s)
        --- PASS: TestVaTestSuite/TestVaClient_WaitUntilNoneLeft/timeout_error (1.00s)
        --- PASS: TestVaTestSuite/TestVaClient_WaitUntilNoneLeft/all_deleted (0.00s)
PASS
coverage: 34.8% of statements
ok      github.com/dell/cert-csi/pkg/k8sclient/resources/va     2.191s  coverage: 34.8% of statements
?       github.com/dell/cert-csi/pkg/testcore   [no test files]
?       github.com/dell/cert-csi/pkg/testcore/runner    [no test files]
?       github.com/dell/cert-csi/pkg/testcore/suites    [no test files]
=== RUN   TestPlotterTestSuite
=== RUN   TestPlotterTestSuite/TestPlotAvgStageTimeOverIterations
=== RUN   TestPlotterTestSuite/TestPlotAvgStageTimeOverIterations/all_empty
=== RUN   TestPlotterTestSuite/TestPlotAvgStageTimeOverIterations/nil_stage
time="2023-11-16T15:32:43-05:00" level=error msg="can't assert stage type: not-a-key"
=== RUN   TestPlotterTestSuite/TestPlotAvgStageTimeOverIterations/usual_metrics
=== RUN   TestPlotterTestSuite/TestPlotEntityOverTime
=== RUN   TestPlotterTestSuite/TestPlotEntityOverTime/all_empty
time="2023-11-16T15:32:45-05:00" level=error msg="no EntityNumberMetrics provided"
=== RUN   TestPlotterTestSuite/TestPlotEntityOverTime/basic_eot_metric_test
=== RUN   TestPlotterTestSuite/TestPlotIterationTimes
=== RUN   TestPlotterTestSuite/TestPlotIterationTimes/all_empty
time="2023-11-16T15:32:45-05:00" level=error msg="no test cases provided"
=== RUN   TestPlotterTestSuite/TestPlotIterationTimes/eot_empty
time="2023-11-16T15:32:45-05:00" level=warning msg="no EntityNumberMetrics provided"
=== RUN   TestPlotterTestSuite/TestPlotIterationTimes/three_simple_test_cases
=== RUN   TestPlotterTestSuite/TestPlotIterationTimes/no_eot_in_later_stages
time="2023-11-16T15:32:46-05:00" level=error msg="IterTimes: No EntityNumberMetrics provided in ProvisioningSuite1"
=== RUN   TestPlotterTestSuite/TestPlotMinMaxEntityOverTime
=== RUN   TestPlotterTestSuite/TestPlotMinMaxEntityOverTime/all_empty
time="2023-11-16T15:32:46-05:00" level=error msg="No test cases provided"
=== RUN   TestPlotterTestSuite/TestPlotMinMaxEntityOverTime/eot_empty
time="2023-11-16T15:32:46-05:00" level=error msg="no EntityMetrics provided"
=== RUN   TestPlotterTestSuite/TestPlotMinMaxEntityOverTime/basic_eot_metric_test
=== RUN   TestPlotterTestSuite/TestPlotMinMaxEntityOverTime/min_max_eot_metric_test
=== RUN   TestPlotterTestSuite/TestPlotMinMaxEntityOverTime/no_eot_in_later_stages
time="2023-11-16T15:32:51-05:00" level=error msg="MinMaxEoT: No EntityNumberMetrics provided in ProvisioningSuite1"
=== RUN   TestPlotterTestSuite/TestPlotResourceUsageOverTime
=== RUN   TestPlotterTestSuite/TestPlotResourceUsageOverTime/all_empty
time="2023-11-16T15:32:53-05:00" level=error msg="no test cases provided"
=== RUN   TestPlotterTestSuite/TestPlotResourceUsageOverTime/resource_usage_empty
time="2023-11-16T15:32:53-05:00" level=warning msg="No ResourceUsageMetrics provided"
=== RUN   TestPlotterTestSuite/TestPlotResourceUsageOverTime/basic_resource_usage
=== RUN   TestPlotterTestSuite/TestPlotStageBoxPlot
=== RUN   TestPlotterTestSuite/TestPlotStageBoxPlot/all_empty
time="2023-11-16T15:32:55-05:00" level=error msg="can't assert stage type: <nil>"
=== RUN   TestPlotterTestSuite/TestPlotStageBoxPlot/pvccreation;tc_and_name_--_empty
time="2023-11-16T15:32:55-05:00" level=error msg="Can't create new box plot; error=plotter: no data points"
=== RUN   TestPlotterTestSuite/TestPlotStageBoxPlot/simple_metrics
=== RUN   TestPlotterTestSuite/TestPlotStageBoxPlot/pod_stage_example
=== RUN   TestPlotterTestSuite/TestPlotStageMetricHistogram
=== RUN   TestPlotterTestSuite/TestPlotStageMetricHistogram/all_empty
time="2023-11-16T15:32:56-05:00" level=error msg="can't assert stage type: <nil>"
=== RUN   TestPlotterTestSuite/TestPlotStageMetricHistogram/pvccreation;tc_and_name_--_empty
=== RUN   TestPlotterTestSuite/TestPlotStageMetricHistogram/simple_metrics
=== RUN   TestPlotterTestSuite/TestPlotStageMetricHistogram/high_maximum
=== RUN   TestPlotterTestSuite/TestPlotStageMetricHistogram/pod_stage_example
--- PASS: TestPlotterTestSuite (15.59s)
    --- PASS: TestPlotterTestSuite/TestPlotAvgStageTimeOverIterations (3.10s)
        --- PASS: TestPlotterTestSuite/TestPlotAvgStageTimeOverIterations/all_empty (0.00s)
        --- PASS: TestPlotterTestSuite/TestPlotAvgStageTimeOverIterations/nil_stage (1.34s)
        --- PASS: TestPlotterTestSuite/TestPlotAvgStageTimeOverIterations/usual_metrics (1.75s)
    --- PASS: TestPlotterTestSuite/TestPlotEntityOverTime (0.59s)
        --- PASS: TestPlotterTestSuite/TestPlotEntityOverTime/all_empty (0.00s)
        --- PASS: TestPlotterTestSuite/TestPlotEntityOverTime/basic_eot_metric_test (0.59s)
    --- PASS: TestPlotterTestSuite/TestPlotIterationTimes (0.97s)
        --- PASS: TestPlotterTestSuite/TestPlotIterationTimes/all_empty (0.00s)
        --- PASS: TestPlotterTestSuite/TestPlotIterationTimes/eot_empty (0.00s)
        --- PASS: TestPlotterTestSuite/TestPlotIterationTimes/three_simple_test_cases (0.52s)
        --- PASS: TestPlotterTestSuite/TestPlotIterationTimes/no_eot_in_later_stages (0.45s)
    --- PASS: TestPlotterTestSuite/TestPlotMinMaxEntityOverTime (6.57s)
        --- PASS: TestPlotterTestSuite/TestPlotMinMaxEntityOverTime/all_empty (0.00s)
        --- PASS: TestPlotterTestSuite/TestPlotMinMaxEntityOverTime/eot_empty (0.00s)
        --- PASS: TestPlotterTestSuite/TestPlotMinMaxEntityOverTime/basic_eot_metric_test (2.14s)
        --- PASS: TestPlotterTestSuite/TestPlotMinMaxEntityOverTime/min_max_eot_metric_test (2.26s)
        --- PASS: TestPlotterTestSuite/TestPlotMinMaxEntityOverTime/no_eot_in_later_stages (2.17s)
    --- PASS: TestPlotterTestSuite/TestPlotResourceUsageOverTime (2.06s)
        --- PASS: TestPlotterTestSuite/TestPlotResourceUsageOverTime/all_empty (0.00s)
        --- PASS: TestPlotterTestSuite/TestPlotResourceUsageOverTime/resource_usage_empty (0.00s)
        --- PASS: TestPlotterTestSuite/TestPlotResourceUsageOverTime/basic_resource_usage (2.06s)
    --- PASS: TestPlotterTestSuite/TestPlotStageBoxPlot (0.65s)
        --- PASS: TestPlotterTestSuite/TestPlotStageBoxPlot/all_empty (0.00s)
        --- PASS: TestPlotterTestSuite/TestPlotStageBoxPlot/pvccreation;tc_and_name_--_empty (0.00s)
        --- PASS: TestPlotterTestSuite/TestPlotStageBoxPlot/simple_metrics (0.32s)
        --- PASS: TestPlotterTestSuite/TestPlotStageBoxPlot/pod_stage_example (0.33s)
    --- PASS: TestPlotterTestSuite/TestPlotStageMetricHistogram (1.63s)
        --- PASS: TestPlotterTestSuite/TestPlotStageMetricHistogram/all_empty (0.00s)
        --- PASS: TestPlotterTestSuite/TestPlotStageMetricHistogram/pvccreation;tc_and_name_--_empty (0.32s)
        --- PASS: TestPlotterTestSuite/TestPlotStageMetricHistogram/simple_metrics (0.39s)
        --- PASS: TestPlotterTestSuite/TestPlotStageMetricHistogram/high_maximum (0.61s)
        --- PASS: TestPlotterTestSuite/TestPlotStageMetricHistogram/pod_stage_example (0.31s)
PASS
coverage: 85.2% of statements
ok      github.com/dell/cert-csi/pkg/plotter    16.671s coverage: 85.2% of statements
=== RUN   TestReporterTestSuite
=== RUN   TestReporterTestSuite/TestGenerateAllReports
=== RUN   TestReporterTestSuite/TestGenerateAllReports/nil_dbs
time="2023-11-16T15:32:42-05:00" level=info msg="Started generating reports..."
=== RUN   TestReporterTestSuite/TestGenerateAllReports/no_run_in_dbs
time="2023-11-16T15:32:42-05:00" level=info msg="Started generating reports..."
time="2023-11-16T15:32:42-05:00" level=warning msg="unable to collect metrics for the test run: "
=== RUN   TestReporterTestSuite/TestGenerateAllReports/successful_test_run
time="2023-11-16T15:32:42-05:00" level=info msg="Started generating reports..."
Collecting metrics
0 [__________________________________________________________________________________________________________________________________________________________________] ?% ? p/sGenerating plots
0 [__________________________________________________________________________________________________________________________________________________________________] ?% ? p/stime="2023-11-16T15:32:42-05:00" level=error msg="No test cases provided"
time="2023-11-16T15:32:42-05:00" level=error msg="no test cases provided"
time="2023-11-16T15:32:42-05:00" level=error msg="no test cases provided"
time="2023-11-16T15:32:42-05:00" level=error msg="no test cases provided"
time="2023-11-16T15:32:42-05:00" level=error msg="no test cases provided"
time="2023-11-16T15:32:42-05:00" level=error msg="no test cases provided"
report-test-run-d6d1f7c8:
Name: test-run-d6d1f7c8
Host: https://10.225.105.62:6443
StorageClass: powerstore
Minimum and Maximum EntityOverTime charts:

/root/.cert-csi/tmp/report-tests/reports/test-run-d6d1f7c8/PodsCreatingOverTime.png

/root/.cert-csi/tmp/report-tests/reports/test-run-d6d1f7c8/PodsReadyOverTime.png

/root/.cert-csi/tmp/report-tests/reports/test-run-d6d1f7c8/PodsTerminatingOverTime.png

/root/.cert-csi/tmp/report-tests/reports/test-run-d6d1f7c8/PvcsCreatingOverTime.png

/root/.cert-csi/tmp/report-tests/reports/test-run-d6d1f7c8/PvcsBoundOverTime.png

Tests:

=== RUN   TestReporterTestSuite/TestGenerateAllReports/unsuccessful_test_run
time="2023-11-16T15:32:42-05:00" level=info msg="Started generating reports..."
time="2023-11-16T15:32:42-05:00" level=warning msg="unable to collect metrics for the test run: unsuccessful-test-run"
=== RUN   TestReporterTestSuite/TestGenerateTextReporter
0 [__________________________________________________________________________________________________________________________________________________________________] ?% ? p/sCollecting metrics
report-test-run-d6d1f7c8:
Name: test-run-d6d1f7c8
Host: https://10.225.105.62:6443
StorageClass: powerstore
Minimum and Maximum EntityOverTime charts:

/root/.cert-csi/tmp/report-tests/reports/test-run-d6d1f7c8/PodsCreatingOverTime.png

/root/.cert-csi/tmp/report-tests/reports/test-run-d6d1f7c8/PodsReadyOverTime.png

/root/.cert-csi/tmp/report-tests/reports/test-run-d6d1f7c8/PodsTerminatingOverTime.png

/root/.cert-csi/tmp/report-tests/reports/test-run-d6d1f7c8/PvcsCreatingOverTime.png

/root/.cert-csi/tmp/report-tests/reports/test-run-d6d1f7c8/PvcsBoundOverTime.png

Tests:


--- PASS: TestReporterTestSuite (0.10s)
    --- PASS: TestReporterTestSuite/TestGenerateAllReports (0.03s)
        --- PASS: TestReporterTestSuite/TestGenerateAllReports/nil_dbs (0.00s)
        --- PASS: TestReporterTestSuite/TestGenerateAllReports/no_run_in_dbs (0.00s)
        --- PASS: TestReporterTestSuite/TestGenerateAllReports/successful_test_run (0.02s)
        --- PASS: TestReporterTestSuite/TestGenerateAllReports/unsuccessful_test_run (0.00s)
    --- PASS: TestReporterTestSuite/TestGenerateTextReporter (0.01s)
PASS
coverage: 33.2% of statements
ok      github.com/dell/cert-csi/pkg/reporter   1.178s  coverage: 33.2% of statements
=== RUN   TestStoreTestSuite
=== RUN   TestStoreTestSuite/TestAllStores
--- PASS: TestStoreTestSuite (0.03s)
    --- PASS: TestStoreTestSuite/TestAllStores (0.01s)
PASS
coverage: 64.8% of statements
ok      github.com/dell/cert-csi/pkg/store      1.073s  coverage: 64.8% of statements
=== RUN   TestE2eReportParser
=== RUN   TestE2eReportParser/Check_generated_config
TestSuite Name: Kubernetes e2e suite
Total Tests Executed: 47
Total Tests Passed: 47
Total Tests Failed: 0
--- PASS: TestE2eReportParser (0.01s)
    --- PASS: TestE2eReportParser/Check_generated_config (0.01s)
=== RUN   TestDownloadBinary
=== RUN   TestDownloadBinary/Pass_good_version
time="2023-11-16T15:32:43-05:00" level=info msg="Downloading tar file...."
=== RUN   TestDownloadBinary/Pass_bad_version
--- PASS: TestDownloadBinary (7.82s)
    --- PASS: TestDownloadBinary/Pass_good_version (7.82s)
    --- PASS: TestDownloadBinary/Pass_bad_version (0.00s)
=== RUN   TestUnTarBinary
=== RUN   TestUnTarBinary/Untar_if_file_present
time="2023-11-16T15:32:51-05:00" level=info msg="Downloading tar file...."
time="2023-11-16T15:32:58-05:00" level=info msg="Untaring...: kubernetes-test-linux-amd64.tar.gz"
time="2023-11-16T15:33:10-05:00" level=info msg="kubernetes/\nkubernetes/test/\nkubernetes/test/bin/\nkubernetes/test/bin/e2e_node.test\nkubernetes/test/bin/gendocs\nkubernetes/test/bin/e2e.test\nkubernetes/test/bin/go-runner\nkubernetes/test/bin/ginkgo\nkubernetes/test/bin/genswaggertypedocs\nkubernetes/test/bin/linkcheck\nkubernetes/test/bin/genman\nkubernetes/test/bin/genyaml\nkubernetes/test/bin/kubemark\nkubernetes/test/bin/genkubedocs\n"
=== RUN   TestUnTarBinary/Untar_if_file_not_present
time="2023-11-16T15:33:11-05:00" level=info msg="Untaring...: kubernetes-test-linux-amd64.tar.gz"
time="2023-11-16T15:33:11-05:00" level=error msg="Unable to untar binaryfile with error: exit status 2"
--- PASS: TestUnTarBinary (19.51s)
    --- PASS: TestUnTarBinary/Untar_if_file_present (19.44s)
    --- PASS: TestUnTarBinary/Untar_if_file_not_present (0.07s)
=== RUN   TestCheckKubeConfigEnv
=== RUN   TestCheckKubeConfigEnv/check_if_KUBECONFIG_is_not_set
time="2023-11-16T15:33:11-05:00" level=info msg="KUBECONFIG env varibale is not set switching to default kube config '~/.kube/config'"
=== RUN   TestCheckKubeConfigEnv/check_if_KUBECONFIG_is_set
--- PASS: TestCheckKubeConfigEnv (0.00s)
    --- PASS: TestCheckKubeConfigEnv/check_if_KUBECONFIG_is_not_set (0.00s)
    --- PASS: TestCheckKubeConfigEnv/check_if_KUBECONFIG_is_set (0.00s)
=== RUN   TestFileExists
=== RUN   TestFileExists/Check_if_file_exist
time="2023-11-16T15:33:11-05:00" level=info msg="Checking file /root/.bashrc"
=== RUN   TestFileExists/Check_if_file_not_exist
time="2023-11-16T15:33:11-05:00" level=info msg="Checking file /root/badfile"
--- PASS: TestFileExists (0.00s)
    --- PASS: TestFileExists/Check_if_file_exist (0.00s)
    --- PASS: TestFileExists/Check_if_file_not_exist (0.00s)
=== RUN   TestPrechecks
=== RUN   TestPrechecks/send_bad_config_file
time="2023-11-16T15:33:11-05:00" level=info msg="Checking file config.yaml"
time="2023-11-16T15:33:11-05:00" level=error msg="Driver config file not found: config.yaml "
=== RUN   TestPrechecks/send_good_config_file
time="2023-11-16T15:33:11-05:00" level=info msg="Checking file testdata/config-nfs.yaml"
--- PASS: TestPrechecks (0.00s)
    --- PASS: TestPrechecks/send_bad_config_file (0.00s)
    --- PASS: TestPrechecks/send_good_config_file (0.00s)
=== RUN   TestGetURL
=== RUN   TestGetURL/valid_version27
=== RUN   TestGetURL/valid_version26
=== RUN   TestGetURL/valid_version25
=== RUN   TestGetURL/invalid_version
--- PASS: TestGetURL (0.00s)
    --- PASS: TestGetURL/valid_version27 (0.00s)
    --- PASS: TestGetURL/valid_version26 (0.00s)
    --- PASS: TestGetURL/valid_version25 (0.00s)
    --- PASS: TestGetURL/invalid_version (0.00s)
=== RUN   TestCheckIfBinaryExists
=== RUN   TestCheckIfBinaryExists/check_with_valid_version
time="2023-11-16T15:33:11-05:00" level=info msg="Downloading tar file...."
time="2023-11-16T15:33:17-05:00" level=info msg="Untaring...: kubernetes-test-linux-amd64.tar.gz"
time="2023-11-16T15:33:30-05:00" level=info msg="kubernetes/\nkubernetes/test/\nkubernetes/test/bin/\nkubernetes/test/bin/e2e_node.test\nkubernetes/test/bin/gendocs\nkubernetes/test/bin/e2e.test\nkubernetes/test/bin/go-runner\nkubernetes/test/bin/ginkgo\nkubernetes/test/bin/genswaggertypedocs\nkubernetes/test/bin/linkcheck\nkubernetes/test/bin/genman\nkubernetes/test/bin/genyaml\nkubernetes/test/bin/kubemark\nkubernetes/test/bin/genkubedocs\n"
=== RUN   TestCheckIfBinaryExists/check_with_invalid_version
--- PASS: TestCheckIfBinaryExists (19.65s)
    --- PASS: TestCheckIfBinaryExists/check_with_valid_version (19.47s)
    --- PASS: TestCheckIfBinaryExists/check_with_invalid_version (0.17s)
=== RUN   TestPrerequisites
=== RUN   TestPrerequisites/check_with_valid_version
time="2023-11-16T15:33:30-05:00" level=info msg="Creating report directory: /root/reports/"
time="2023-11-16T15:33:30-05:00" level=info msg="Found the Kuberners e2e Binary with version:v1.25.0 "
=== RUN   TestPrerequisites/check_with_invalid_version
time="2023-11-16T15:33:30-05:00" level=info msg="Creating report directory: /root/reports/"
time="2023-11-16T15:33:30-05:00" level=info msg="Kuberners e2e Binary with version:v1.2.0 not found "
--- PASS: TestPrerequisites (0.27s)
    --- PASS: TestPrerequisites/check_with_valid_version (0.14s)
    --- PASS: TestPrerequisites/check_with_invalid_version (0.13s)
=== RUN   TestReadTestDriverConfig
=== RUN   TestReadTestDriverConfig/get_storage_class_name
--- PASS: TestReadTestDriverConfig (0.00s)
    --- PASS: TestReadTestDriverConfig/get_storage_class_name (0.00s)
=== RUN   TestSkipTests
=== RUN   TestSkipTests/get_skip_tests
--- PASS: TestSkipTests (0.00s)
    --- PASS: TestSkipTests/get_skip_tests (0.00s)
=== RUN   TestBuildE2eCommand
=== RUN   TestBuildE2eCommand/send_bad_config_file
time="2023-11-16T15:33:30-05:00" level=info msg="Checking file config.yaml"
time="2023-11-16T15:33:30-05:00" level=error msg="Driver config file not found: config.yaml"
=== RUN   TestBuildE2eCommand/send_good_config_file
time="2023-11-16T15:33:30-05:00" level=info msg="Checking file testdata/config-nfs.yaml"
time="2023-11-16T15:33:30-05:00" level=info msg="Checking file /root/reports/execution_powerstore-nfs.xml"
--- PASS: TestBuildE2eCommand (0.00s)
    --- PASS: TestBuildE2eCommand/send_bad_config_file (0.00s)
    --- PASS: TestBuildE2eCommand/send_good_config_file (0.00s)
=== RUN   TestExecuteE2ECommand
=== RUN   TestExecuteE2ECommand/execute_with_proper_arguments
time="2023-11-16T15:33:30-05:00" level=info msg="e2e command arguments are: [-kubeconfig /root/.kube/config -storage.testdriver testdata/config-nfs.yaml --ginkgo.skip *]"
Nov 16 15:33:31.128: INFO: Driver loaded from path [testdata/config-nfs.yaml]: &{DriverInfo:{Name:csi-powerstore.dellemc.com InTreePluginName: FeatureTag: MaxFileSize:0 SupportedSizeRange:{Max: Min:3Gi} SupportedFsType:map[:{} nfs:{}] SupportedMountOption:map[] RequiredMountOption:map[] Capabilities:map[block:false capacity:true controllerExpansion:true exec:true fsGroup:true multipods:true nodeExpansion:false offlineExpansion:true onlineExpansion:true persistence:true pvcDataSource:true readWriteOncePod:true snapshotDataSource:true topology:true volumeLimits:false] RequiredAccessModes:[] TopologyKeys:[csi-powerstore.dellemc.com/10.10.10.10-nfs csi-powerstore.dellemc.com/10.10.10.10-iscsi] NumAllowedTopologies:0 StressTestOptions:0xc0005e70a0 VolumeSnapshotStressTestOptions:0xc0005e7110 PerformanceTestOptions:0xc0006cb160} StorageClass:{FromName:false FromFile: FromExistingClassName:powerstore-nfs} SnapshotClass:{FromName:false FromFile: FromExistingClassName:powerstore-snapclass} InlineVolumes:[{Attributes:map[arrayID:myarrayid nasName:team-nas protocol:NFS size:5Gi] Shared:true ReadOnly:false}] ClientNodeName: Timeouts:map[]}
Nov 16 15:33:31.128: INFO: The --provider flag is not set. Continuing as if --provider=skeleton had been used.
I1116 15:33:31.129184   21124 e2e.go:116] Starting e2e run "32e088d7-03b8-411b-9149-e742878aea12" on Ginkgo node 1
Nov 16 15:33:31.149: INFO: Enabling in-tree volume drivers
--- FAIL: TestE2E (0.16s)
panic: regexp: Compile(`*`): error parsing regexp: missing argument to repetition operator: `*` [recovered]
        panic: regexp: Compile(`*`): error parsing regexp: missing argument to repetition operator: `*`

goroutine 119 [running]:
testing.tRunner.func1.2({0x64ff8a0, 0xc001400000})
        /usr/local/go/src/testing/testing.go:1396 +0x24e
testing.tRunner.func1()
        /usr/local/go/src/testing/testing.go:1399 +0x39f
panic({0x64ff8a0, 0xc001400000})
        /usr/local/go/src/runtime/panic.go:884 +0x212
regexp.MustCompile({0x7fff26412746, 0x1})
        /usr/local/go/src/regexp/regexp.go:319 +0xbb
k8s.io/kubernetes/vendor/github.com/onsi/ginkgo/v2/internal.ApplyFocusToSpecs({0xc002bb2000, 0x1ca7, 0x7c0e998?}, {0x7399601, _}, {_, _, _}, {0x65567c9b, 0x1, ...})
        vendor/github.com/onsi/ginkgo/v2/internal/focus.go:108 +0x753
k8s.io/kubernetes/vendor/github.com/onsi/ginkgo/v2/internal.(*Suite).Run(_, {_, _}, {_, _, _}, {_, _}, _, {0x7c60e28, ...}, ...)
        vendor/github.com/onsi/ginkgo/v2/internal/suite.go:72 +0x105
k8s.io/kubernetes/vendor/github.com/onsi/ginkgo/v2.RunSpecs({0x7c2dd80, 0xc0004536c0}, {0x7399601, 0x14}, {0xc0008059a8?, 0x2, 0x0?})
        vendor/github.com/onsi/ginkgo/v2/core_dsl.go:280 +0xa13
k8s.io/kubernetes/test/e2e.RunE2ETests(0xc0004536c0?)
        test/e2e/e2e.go:117 +0x6bc
k8s.io/kubernetes/test/e2e.TestE2E(0x2560299?)
        test/e2e/e2e_test.go:139 +0x19
testing.tRunner(0xc0004536c0, 0x761c1f0)
        /usr/local/go/src/testing/testing.go:1446 +0x10b
created by testing.(*T).Run
        /usr/local/go/src/testing/testing.go:1493 +0x35f
--- PASS: TestExecuteE2ECommand (0.31s)
    --- PASS: TestExecuteE2ECommand/execute_with_proper_arguments (0.31s)
=== RUN   TestGenerateReport
=== RUN   TestGenerateReport/send_correct_report_
TestSuite Name: Kubernetes e2e suite
Total Tests Executed: 47
Total Tests Passed: 47
Total Tests Failed: 0
--- PASS: TestGenerateReport (0.01s)
    --- PASS: TestGenerateReport/send_correct_report_ (0.01s)
=== RUN   TestParse
--- PASS: TestParse (0.00s)
PASS
coverage: 72.2% of statements
```
