### PR TITLE
Configurable container images for cert-csi

### DIFF
--- a/pkg/cmd/certifycmd.go
+++ b/pkg/cmd/certifycmd.go
@@ -185,9 +185,16 @@ func GetCertifyCommand() cli.Command {
 				return fmt.Errorf("unable to decode Config: %s", err)
 			}
 
-			imageConfig, err := readImageConfig(c.String("image-config"))
-			if err != nil {
-				return fmt.Errorf("failed to find image Config: %s", err)
+			imageConfigPath := c.String("image-config")
+			var testImage string
+			if imageConfigPath != "" {
+				img, err := readImageConfig(imageConfigPath)
+				if err != nil {
+					return fmt.Errorf("failed to find image Config: %s", err)
+				}
+				for _, img := range img.Images {
+					testImage = img.Test
+				}
 			}
 			// Parse timeout
 			timeout, err := time.ParseDuration(c.String("timeout"))
@@ -220,7 +227,7 @@ func GetCertifyCommand() cli.Command {
 					VolumeSize:   minSize,
 					ChainNumber:  2,
 					ChainLength:  2,
-					Image:        imageConfig.CentOSImage,
+					Image:        testImage,
 				})
 
 				s = append(s, &suites.ScalingSuite{
@@ -229,7 +236,7 @@ func GetCertifyCommand() cli.Command {
 					GradualScaleDown: false,
 					PodPolicy:        "Parallel",
 					VolumeSize:       minSize,
-					Image:            imageConfig.CentOSImage,
+					Image:            testImage,
 				})
 
 				if sc.Clone {
@@ -237,7 +244,7 @@ func GetCertifyCommand() cli.Command {
 						VolumeNumber: 1,
 						PodNumber:    2,
 						VolumeSize:   minSize,
-						Image:        imageConfig.CentOSImage,
+						Image:        testImage,
 					})
 
 				}
@@ -250,7 +257,7 @@ func GetCertifyCommand() cli.Command {
 						PodNumber:    1,
 						InitialSize:  minSize,
 						ExpandedSize: expSize.String(),
-						Image:        imageConfig.CentOSImage,
+						Image:        testImage,
 					})
 
 					if sc.RawBlock {
@@ -260,7 +267,7 @@ func GetCertifyCommand() cli.Command {
 							IsBlock:      true,
 							InitialSize:  minSize,
 							ExpandedSize: expSize.String(),
-							Image:        imageConfig.CentOSImage,
+							Image:        testImage,
 						})
 					}
 				}
@@ -274,7 +281,7 @@ func GetCertifyCommand() cli.Command {
 						SnapAmount: 3,
 						SnapClass:  snapClass,
 						VolumeSize: minSize,
-						Image:      imageConfig.CentOSImage,
+						Image:      testImage,
 					})
 
 					s = append(s, &suites.ReplicationSuite{
@@ -282,7 +289,7 @@ func GetCertifyCommand() cli.Command {
 						VolumeSize:   minSize,
 						PodNumber:    2,
 						SnapClass:    snapClass,
-						Image:        imageConfig.CentOSImage,
+						Image:        testImage,
 					})
 				}
 
@@ -292,7 +299,7 @@ func GetCertifyCommand() cli.Command {
 						RawBlock:   true,
 						AccessMode: "ReadWriteMany",
 						VolumeSize: minSize,
-						Image:      imageConfig.CentOSImage,
+						Image:      testImage,
 					})
 				}
 
@@ -302,7 +309,7 @@ func GetCertifyCommand() cli.Command {
 						RawBlock:   false,
 						AccessMode: "ReadWriteMany",
 						VolumeSize: minSize,
-						Image:      imageConfig.CentOSImage,
+						Image:      testImage,
 					})
 				}
 
@@ -312,7 +319,7 @@ func GetCertifyCommand() cli.Command {
 						VolumeNumber: 1,
 						VolumeSize:   minSize,
 						Namespace:    c.String("driver-namespace"),
-						Image:        imageConfig.CentOSImage,
+						Image:        testImage,
 					})
 				}
 
@@ -322,7 +329,7 @@ func GetCertifyCommand() cli.Command {
 						RawBlock:   false,
 						AccessMode: "ReadWriteOncePod",
 						VolumeSize: minSize,
-						Image:      imageConfig.CentOSImage,
+						Image:      testImage,
 					})
 				}
 
@@ -332,7 +339,7 @@ func GetCertifyCommand() cli.Command {
 						FSType:           sc.Ephemeral.FSType,
 						PodNumber:        2,
 						VolumeAttributes: sc.Ephemeral.VolumeAttributes,
-						Image:            imageConfig.CentOSImage,
+						Image:            testImage,
 					})
 				}
 				if sc.VGS {
@@ -361,7 +368,7 @@ func GetCertifyCommand() cli.Command {
 						VolumeNumber:    2,
 						Driver:          driverName,
 						VolumeGroupName: vgsName,
-						Image:           imageConfig.CentOSImage,
+						Image:           testImage,
 					})
 				}
 				if sc.CapacityTracking != nil {
@@ -370,7 +377,7 @@ func GetCertifyCommand() cli.Command {
 						StorageClass:    sc.Name,
 						VolumeSize:      minSize,
 						PollInterval:    sc.CapacityTracking.PollInterval,
-						Image:           imageConfig.CentOSImage,
+						Image:           testImage,
 					})
 				}
 				log.Infof("Suites to run with %s storage class:", color.CyanString(sc.Name))

--- a/pkg/cmd/certifycmd.go
+++ b/pkg/cmd/certifycmd.go
@@ -84,6 +84,10 @@ func GetCertifyCommand() cli.Command {
 					Required: true,
 				},
 				cli.StringFlag{
+					Name:  "image-config",
+					Usage: "path to images config file",
+				},
+				cli.StringFlag{
 					Name:   "config, conf, c",
 					Usage:  "config for connecting to kubernetes",
 					EnvVar: "KUBECONFIG",
@@ -181,6 +185,10 @@ func GetCertifyCommand() cli.Command {
 				return fmt.Errorf("unable to decode Config: %s", err)
 			}
 
+			imageConfig, err := readImageConfig(c.String("image-config"))
+			if err != nil {
+				return fmt.Errorf("failed to find image Config: %s", err)
+			}
 			// Parse timeout
 			timeout, err := time.ParseDuration(c.String("timeout"))
 			if err != nil {
@@ -212,6 +220,7 @@ func GetCertifyCommand() cli.Command {
 					VolumeSize:   minSize,
 					ChainNumber:  2,
 					ChainLength:  2,
+					Image:        imageConfig.CentOSImage,
 				})
 
 				s = append(s, &suites.ScalingSuite{
@@ -220,6 +229,7 @@ func GetCertifyCommand() cli.Command {
 					GradualScaleDown: false,
 					PodPolicy:        "Parallel",
 					VolumeSize:       minSize,
+					Image:            imageConfig.CentOSImage,
 				})
 
 				if sc.Clone {
@@ -227,6 +237,7 @@ func GetCertifyCommand() cli.Command {
 						VolumeNumber: 1,
 						PodNumber:    2,
 						VolumeSize:   minSize,
+						Image:        imageConfig.CentOSImage,
 					})
 
 				}
@@ -239,6 +250,7 @@ func GetCertifyCommand() cli.Command {
 						PodNumber:    1,
 						InitialSize:  minSize,
 						ExpandedSize: expSize.String(),
+						Image:        imageConfig.CentOSImage,
 					})
 
 					if sc.RawBlock {
@@ -248,6 +260,7 @@ func GetCertifyCommand() cli.Command {
 							IsBlock:      true,
 							InitialSize:  minSize,
 							ExpandedSize: expSize.String(),
+							Image:        imageConfig.CentOSImage,
 						})
 					}
 				}
@@ -261,6 +274,7 @@ func GetCertifyCommand() cli.Command {
 						SnapAmount: 3,
 						SnapClass:  snapClass,
 						VolumeSize: minSize,
+						Image:      imageConfig.CentOSImage,
 					})
 
 					s = append(s, &suites.ReplicationSuite{
@@ -268,6 +282,7 @@ func GetCertifyCommand() cli.Command {
 						VolumeSize:   minSize,
 						PodNumber:    2,
 						SnapClass:    snapClass,
+						Image:        imageConfig.CentOSImage,
 					})
 				}
 
@@ -277,6 +292,7 @@ func GetCertifyCommand() cli.Command {
 						RawBlock:   true,
 						AccessMode: "ReadWriteMany",
 						VolumeSize: minSize,
+						Image:      imageConfig.CentOSImage,
 					})
 				}
 
@@ -286,6 +302,7 @@ func GetCertifyCommand() cli.Command {
 						RawBlock:   false,
 						AccessMode: "ReadWriteMany",
 						VolumeSize: minSize,
+						Image:      imageConfig.CentOSImage,
 					})
 				}
 
@@ -295,6 +312,7 @@ func GetCertifyCommand() cli.Command {
 						VolumeNumber: 1,
 						VolumeSize:   minSize,
 						Namespace:    c.String("driver-namespace"),
+						Image:        imageConfig.CentOSImage,
 					})
 				}
 
@@ -304,6 +322,7 @@ func GetCertifyCommand() cli.Command {
 						RawBlock:   false,
 						AccessMode: "ReadWriteOncePod",
 						VolumeSize: minSize,
+						Image:      imageConfig.CentOSImage,
 					})
 				}
 
@@ -313,6 +332,7 @@ func GetCertifyCommand() cli.Command {
 						FSType:           sc.Ephemeral.FSType,
 						PodNumber:        2,
 						VolumeAttributes: sc.Ephemeral.VolumeAttributes,
+						Image:            imageConfig.CentOSImage,
 					})
 				}
 				if sc.VGS {
@@ -341,6 +361,7 @@ func GetCertifyCommand() cli.Command {
 						VolumeNumber:    2,
 						Driver:          driverName,
 						VolumeGroupName: vgsName,
+						Image:           imageConfig.CentOSImage,
 					})
 				}
 				if sc.CapacityTracking != nil {
@@ -349,6 +370,7 @@ func GetCertifyCommand() cli.Command {
 						StorageClass:    sc.Name,
 						VolumeSize:      minSize,
 						PollInterval:    sc.CapacityTracking.PollInterval,
+						Image:           imageConfig.CentOSImage,
 					})
 				}
 				log.Infof("Suites to run with %s storage class:", color.CyanString(sc.Name))

--- a/pkg/cmd/functionalcmd.go
+++ b/pkg/cmd/functionalcmd.go
@@ -425,9 +425,16 @@ func getFunctionalCloneVolumeCommand(globalFlags []cli.Flag) cli.Command {
 			pvcName := c.String("pvc-name")
 			podName := c.String("pod-name")
 			accessMode := c.String("access-mode")
-			image, err := readImageConfig(c.String("image-config"))
-			if err != nil {
-				return fmt.Errorf("failed to find image Config: %s", err)
+			imageConfigPath := c.String("image-config")
+			var testImage string
+			if imageConfigPath != "" {
+				img, err := readImageConfig(imageConfigPath)
+				if err != nil {
+					return fmt.Errorf("failed to find image Config: %s", err)
+				}
+				for _, img := range img.Images {
+					testImage = img.Test
+				}
 			}
 
 			s := []suites.Interface{
@@ -438,7 +445,7 @@ func getFunctionalCloneVolumeCommand(globalFlags []cli.Flag) cli.Command {
 					CustomPvcName: pvcName,
 					CustomPodName: podName,
 					AccessMode:    accessMode,
-					Image:         image.CentOSImage,
+					Image:         testImage,
 				},
 			}
 
@@ -497,9 +504,16 @@ func getFunctionalProvisioningCommand(globalFlags []cli.Flag) cli.Command {
 			desc := c.String("description")
 			volAccessMode := c.String("vol-access-mode")
 			roFlag := c.Bool("roFlag")
-			image, err := readImageConfig(c.String("image-config"))
-			if err != nil {
-				return fmt.Errorf("failed to find image Config: %s", err)
+			imageConfigPath := c.String("image-config")
+			var testImage string
+			if imageConfigPath != "" {
+				img, err := readImageConfig(imageConfigPath)
+				if err != nil {
+					return fmt.Errorf("failed to find image Config: %s", err)
+				}
+				for _, img := range img.Images {
+					testImage = img.Test
+				}
 			}
 			s := []suites.Interface{
 				&suites.ProvisioningSuite{
@@ -510,7 +524,7 @@ func getFunctionalProvisioningCommand(globalFlags []cli.Flag) cli.Command {
 					RawBlock:      blockVol,
 					VolAccessMode: volAccessMode,
 					ROFlag:        roFlag,
-					Image:         image.CentOSImage,
+					Image:         testImage,
 				},
 			}
 
@@ -571,9 +585,16 @@ func getFunctionalSnapCreationCommand(globalFlags []cli.Flag) cli.Command {
 			desc := c.String("description")
 			snapName := c.String("snap-name")
 			accessModeRestored := c.String("access-mode-restored-volume")
-			image, err := readImageConfig(c.String("image-config"))
-			if err != nil {
-				return fmt.Errorf("failed to find image Config: %s", err)
+			imageConfigPath := c.String("image-config")
+			var testImage string
+			if imageConfigPath != "" {
+				img, err := readImageConfig(imageConfigPath)
+				if err != nil {
+					return fmt.Errorf("failed to find image Config: %s", err)
+				}
+				for _, img := range img.Images {
+					testImage = img.Test
+				}
 			}
 			s := []suites.Interface{
 				&suites.SnapSuite{
@@ -584,7 +605,7 @@ func getFunctionalSnapCreationCommand(globalFlags []cli.Flag) cli.Command {
 					CustomSnapName:     snapName,
 					AccessModeOriginal: accessModeOriginal,
 					AccessModeRestored: accessModeRestored,
-					Image:              image.CentOSImage,
+					Image:              testImage,
 				},
 			}
 
@@ -630,18 +651,24 @@ func getFunctionalMultiAttachVolCommand(globalFlags []cli.Flag) cli.Command {
 			desc := c.String("description")
 			isRawBlock := c.Bool("block")
 			accessMode := c.String("access-mode")
-			image, err := readImageConfig(c.String("image-config"))
-			if err != nil {
-				return fmt.Errorf("failed to find image Config: %s", err)
+			imageConfigPath := c.String("image-config")
+			var testImage string
+			if imageConfigPath != "" {
+				img, err := readImageConfig(imageConfigPath)
+				if err != nil {
+					return fmt.Errorf("failed to find image Config: %s", err)
+				}
+				for _, img := range img.Images {
+					testImage = img.Test
+				}
 			}
-
 			s := []suites.Interface{
 				&suites.MultiAttachSuite{
 					PodNumber:   pods,
 					RawBlock:    isRawBlock,
 					Description: desc,
 					AccessMode:  accessMode,
-					Image:       image.CentOSImage,
+					Image:       testImage,
 				},
 			}
 
@@ -693,11 +720,17 @@ func getFunctionalEphemeralCreationCommand(globalFlags []cli.Flag) cli.Command {
 			fsType := c.String("fs-type")
 			attributesFile := c.String("csi-attributes")
 			podName := c.String("pod-name")
-			image, err := readImageConfig(c.String("image-config"))
-			if err != nil {
-				return fmt.Errorf("failed to find image Config: %s", err)
+			imageConfigPath := c.String("image-config")
+			var testImage string
+			if imageConfigPath != "" {
+				img, err := readImageConfig(imageConfigPath)
+				if err != nil {
+					return fmt.Errorf("failed to find image Config: %s", err)
+				}
+				for _, img := range img.Images {
+					testImage = img.Test
+				}
 			}
-
 			// We will generate volumeAttributes by reading the properties file
 			volAttributes, err := readEphemeralConfig(attributesFile)
 			if err != nil {
@@ -713,7 +746,7 @@ func getFunctionalEphemeralCreationCommand(globalFlags []cli.Flag) cli.Command {
 					VolumeAttributes: volAttributes,
 					Description:      desc,
 					PodCustomName:    podName,
-					Image:            image.CentOSImage,
+					Image:            testImage,
 				},
 			}
 
@@ -879,9 +912,16 @@ func getCapacityTrackingCommand(globalFlags []cli.Flag) cli.Command {
 			storageClass := c.String("sc")
 			volumeSize := c.String("volSize")
 			pollInterval := c.Duration("poll-interval")
-			image, err := readImageConfig(c.String("image-config"))
-			if err != nil {
-				return fmt.Errorf("failed to find image Config: %s", err)
+			imageConfigPath := c.String("image-config")
+			var testImage string
+			if imageConfigPath != "" {
+				img, err := readImageConfig(imageConfigPath)
+				if err != nil {
+					return fmt.Errorf("failed to find image Config: %s", err)
+				}
+				for _, img := range img.Images {
+					testImage = img.Test
+				}
 			}
 			s := []suites.Interface{
 				&suites.CapacityTrackingSuite{
@@ -889,7 +929,7 @@ func getCapacityTrackingCommand(globalFlags []cli.Flag) cli.Command {
 					StorageClass:    storageClass,
 					VolumeSize:      volumeSize,
 					PollInterval:    pollInterval,
-					Image:           image.CentOSImage,
+					Image:           testImage,
 				},
 			}
 

--- a/pkg/cmd/functionalcmd.go
+++ b/pkg/cmd/functionalcmd.go
@@ -62,6 +62,10 @@ func GetFunctionalTestCommand() cli.Command {
 			Name:  "description, de",
 			Usage: "To provide test case description",
 		},
+		cli.StringFlag{
+			Name:  "image-config",
+			Usage: "path to images config file",
+		},
 	}
 
 	listCmd := cli.Command{
@@ -421,6 +425,10 @@ func getFunctionalCloneVolumeCommand(globalFlags []cli.Flag) cli.Command {
 			pvcName := c.String("pvc-name")
 			podName := c.String("pod-name")
 			accessMode := c.String("access-mode")
+			image, err := readImageConfig(c.String("image-config"))
+			if err != nil {
+				return fmt.Errorf("failed to find image Config: %s", err)
+			}
 
 			s := []suites.Interface{
 				&suites.CloneVolumeSuite{
@@ -430,6 +438,7 @@ func getFunctionalCloneVolumeCommand(globalFlags []cli.Flag) cli.Command {
 					CustomPvcName: pvcName,
 					CustomPodName: podName,
 					AccessMode:    accessMode,
+					Image:         image.CentOSImage,
 				},
 			}
 
@@ -488,6 +497,10 @@ func getFunctionalProvisioningCommand(globalFlags []cli.Flag) cli.Command {
 			desc := c.String("description")
 			volAccessMode := c.String("vol-access-mode")
 			roFlag := c.Bool("roFlag")
+			image, err := readImageConfig(c.String("image-config"))
+			if err != nil {
+				return fmt.Errorf("failed to find image Config: %s", err)
+			}
 			s := []suites.Interface{
 				&suites.ProvisioningSuite{
 					VolumeNumber:  volNum,
@@ -497,6 +510,7 @@ func getFunctionalProvisioningCommand(globalFlags []cli.Flag) cli.Command {
 					RawBlock:      blockVol,
 					VolAccessMode: volAccessMode,
 					ROFlag:        roFlag,
+					Image:         image.CentOSImage,
 				},
 			}
 
@@ -557,6 +571,10 @@ func getFunctionalSnapCreationCommand(globalFlags []cli.Flag) cli.Command {
 			desc := c.String("description")
 			snapName := c.String("snap-name")
 			accessModeRestored := c.String("access-mode-restored-volume")
+			image, err := readImageConfig(c.String("image-config"))
+			if err != nil {
+				return fmt.Errorf("failed to find image Config: %s", err)
+			}
 			s := []suites.Interface{
 				&suites.SnapSuite{
 					SnapClass:          snapClass,
@@ -566,6 +584,7 @@ func getFunctionalSnapCreationCommand(globalFlags []cli.Flag) cli.Command {
 					CustomSnapName:     snapName,
 					AccessModeOriginal: accessModeOriginal,
 					AccessModeRestored: accessModeRestored,
+					Image:              image.CentOSImage,
 				},
 			}
 
@@ -611,6 +630,10 @@ func getFunctionalMultiAttachVolCommand(globalFlags []cli.Flag) cli.Command {
 			desc := c.String("description")
 			isRawBlock := c.Bool("block")
 			accessMode := c.String("access-mode")
+			image, err := readImageConfig(c.String("image-config"))
+			if err != nil {
+				return fmt.Errorf("failed to find image Config: %s", err)
+			}
 
 			s := []suites.Interface{
 				&suites.MultiAttachSuite{
@@ -618,6 +641,7 @@ func getFunctionalMultiAttachVolCommand(globalFlags []cli.Flag) cli.Command {
 					RawBlock:    isRawBlock,
 					Description: desc,
 					AccessMode:  accessMode,
+					Image:       image.CentOSImage,
 				},
 			}
 
@@ -669,6 +693,10 @@ func getFunctionalEphemeralCreationCommand(globalFlags []cli.Flag) cli.Command {
 			fsType := c.String("fs-type")
 			attributesFile := c.String("csi-attributes")
 			podName := c.String("pod-name")
+			image, err := readImageConfig(c.String("image-config"))
+			if err != nil {
+				return fmt.Errorf("failed to find image Config: %s", err)
+			}
 
 			// We will generate volumeAttributes by reading the properties file
 			volAttributes, err := readEphemeralConfig(attributesFile)
@@ -685,6 +713,7 @@ func getFunctionalEphemeralCreationCommand(globalFlags []cli.Flag) cli.Command {
 					VolumeAttributes: volAttributes,
 					Description:      desc,
 					PodCustomName:    podName,
+					Image:            image.CentOSImage,
 				},
 			}
 
@@ -850,12 +879,17 @@ func getCapacityTrackingCommand(globalFlags []cli.Flag) cli.Command {
 			storageClass := c.String("sc")
 			volumeSize := c.String("volSize")
 			pollInterval := c.Duration("poll-interval")
+			image, err := readImageConfig(c.String("image-config"))
+			if err != nil {
+				return fmt.Errorf("failed to find image Config: %s", err)
+			}
 			s := []suites.Interface{
 				&suites.CapacityTrackingSuite{
 					DriverNamespace: driverns,
 					StorageClass:    storageClass,
 					VolumeSize:      volumeSize,
 					PollInterval:    pollInterval,
+					Image:           image.CentOSImage,
 				},
 			}
 

--- a/pkg/testcore/config.go
+++ b/pkg/testcore/config.go
@@ -28,9 +28,13 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-type ImageConfig struct {
-	CentOSImage   string
-	PostgresImage string
+type Image struct {
+	Test     string
+	Postgres string
+}
+
+type Images struct {
+	Images []Image `yaml:"images"`
 }
 
 // VolumeCreationConfig config to use in volumecreation suite

--- a/pkg/testcore/config.go
+++ b/pkg/testcore/config.go
@@ -28,6 +28,11 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
+type ImageConfig struct {
+	CentOSImage   string
+	PostgresImage string
+}
+
 // VolumeCreationConfig config to use in volumecreation suite
 func VolumeCreationConfig(storageclass string, claimSize string, Name string, AccessMode string) *pvc.Config {
 	accessMode := GetAccessMode(AccessMode)
@@ -53,7 +58,7 @@ func MultiAttachVolumeConfig(storageclass string, claimSize string, AccessMode s
 }
 
 // CapacityTrackingPodConfig config to use in capacity-tracking suite
-func CapacityTrackingPodConfig(pvcNames []string, podName string) *pod.Config {
+func CapacityTrackingPodConfig(pvcNames []string, podName string, containerImage string) *pod.Config {
 	return &pod.Config{
 		Name:           podName,
 		NamePrefix:     "pod-capacity-tracking-test-",
@@ -61,14 +66,14 @@ func CapacityTrackingPodConfig(pvcNames []string, podName string) *pod.Config {
 		VolumeName:     "vol",
 		MountPath:      "/data",
 		ContainerName:  "capacity-tracking-test",
-		ContainerImage: "docker.io/centos:latest",
+		ContainerImage: containerImage,
 		Command:        []string{`/bin/bash`},
 		Args:           []string{"-c", "trap 'exit 0' SIGTERM;while true; do sleep 1; done"},
 	}
 }
 
 // ProvisioningPodConfig config to use in provisioning suite
-func ProvisioningPodConfig(pvcNames []string, podName string) *pod.Config {
+func ProvisioningPodConfig(pvcNames []string, podName string, containerImage string) *pod.Config {
 	return &pod.Config{
 		Name:           podName,
 		NamePrefix:     "pod-prov-test-",
@@ -76,14 +81,14 @@ func ProvisioningPodConfig(pvcNames []string, podName string) *pod.Config {
 		VolumeName:     "vol",
 		MountPath:      "/data",
 		ContainerName:  "prov-test",
-		ContainerImage: "docker.io/centos:latest",
+		ContainerImage: containerImage,
 		Command:        []string{`/bin/bash`},
 		Args:           []string{"-c", "trap 'exit 0' SIGTERM;while true; do sleep 1; done"},
 	}
 }
 
 // VolumeHealthPodConfig config to use in provisioning suite
-func VolumeHealthPodConfig(pvcNames []string, podName string) *pod.Config {
+func VolumeHealthPodConfig(pvcNames []string, podName string, containerImage string) *pod.Config {
 	return &pod.Config{
 		Name:           podName,
 		NamePrefix:     "pod-volume-health-test-",
@@ -91,14 +96,14 @@ func VolumeHealthPodConfig(pvcNames []string, podName string) *pod.Config {
 		VolumeName:     "vol",
 		MountPath:      "/data",
 		ContainerName:  "volume-health-test",
-		ContainerImage: "docker.io/centos:latest",
+		ContainerImage: containerImage,
 		Command:        []string{`/bin/bash`},
 		Args:           []string{"-c", "trap 'exit 0' SIGTERM;while true; do sleep 1; done"},
 	}
 }
 
 // IoWritePodConfig config to use in io suite
-func IoWritePodConfig(pvcNames []string, podName string) *pod.Config {
+func IoWritePodConfig(pvcNames []string, podName string, containerImage string) *pod.Config {
 	return &pod.Config{
 		Name:           podName,
 		NamePrefix:     "iowriter-test-",
@@ -106,20 +111,20 @@ func IoWritePodConfig(pvcNames []string, podName string) *pod.Config {
 		VolumeName:     "vol",
 		MountPath:      "/data",
 		ContainerName:  "iowriter",
-		ContainerImage: "docker.io/centos:latest",
+		ContainerImage: containerImage,
 		Command:        []string{`/bin/bash`},
 		Args:           []string{"-c", " trap 'exit 0' SIGTERM;while true; do sleep 1; done"},
 	}
 }
 
 // BlockSnapPodConfig config to use in blocksnap suite
-func BlockSnapPodConfig(pvcNames []string) *pod.Config {
+func BlockSnapPodConfig(pvcNames []string, containerImage string) *pod.Config {
 	return &pod.Config{
 		NamePrefix:     "bs-test-",
 		VolumeName:     "vol",
 		MountPath:      "/data",
 		ContainerName:  "iowriter",
-		ContainerImage: "docker.io/centos:latest",
+		ContainerImage: containerImage,
 		PvcNames:       pvcNames,
 		Command:        []string{`/bin/bash`},
 		Args:           []string{"-c", " trap 'exit 0' SIGTERM;while true; do sleep 1; done"},
@@ -128,14 +133,14 @@ func BlockSnapPodConfig(pvcNames []string) *pod.Config {
 }
 
 // MultiAttachPodConfig config to use in MultiAttachSuite
-func MultiAttachPodConfig(pvcNames []string) *pod.Config {
+func MultiAttachPodConfig(pvcNames []string, containerImage string) *pod.Config {
 	return &pod.Config{
 		NamePrefix:     "iowriter-test-",
 		PvcNames:       pvcNames,
 		VolumeName:     "vol",
 		MountPath:      "/data",
 		ContainerName:  "iowriter",
-		ContainerImage: "docker.io/centos:latest",
+		ContainerImage: containerImage,
 		Command:        []string{`/bin/bash`},
 		Args:           []string{"-c", " trap 'exit 0' SIGTERM;while true; do sleep 1; done"},
 		Capabilities:   []v1.Capability{"SYS_ADMIN"},
@@ -143,7 +148,7 @@ func MultiAttachPodConfig(pvcNames []string) *pod.Config {
 }
 
 // ScalingStsConfig config to use in scaling suite
-func ScalingStsConfig(storageclass string, claimSize string, volumeNumber int, podPolicy string) *statefulset.Config {
+func ScalingStsConfig(storageclass string, claimSize string, volumeNumber int, podPolicy string, containerImage string) *statefulset.Config {
 	return &statefulset.Config{
 		VolumeNumber:        volumeNumber,
 		Replicas:            1,
@@ -153,7 +158,7 @@ func ScalingStsConfig(storageclass string, claimSize string, volumeNumber int, p
 		PodManagementPolicy: podPolicy,
 		ClaimSize:           claimSize,
 		ContainerName:       "scale-test",
-		ContainerImage:      "docker.io/centos:latest",
+		ContainerImage:      containerImage,
 		NamePrefix:          "sts-scale-test",
 		Command:             []string{`/bin/bash`},
 		Args:                []string{"-c", "trap 'exit 0' SIGTERM;while true; do sleep 1; done"},
@@ -162,11 +167,11 @@ func ScalingStsConfig(storageclass string, claimSize string, volumeNumber int, p
 }
 
 // PsqlPodConfig config to use for psql suite
-func PsqlPodConfig(password string) *pod.Config {
+func PsqlPodConfig(password string, containerImage string) *pod.Config {
 	return &pod.Config{
 		NamePrefix:     "psql-client-pod-",
 		ContainerName:  "psql-client",
-		ContainerImage: "docker.io/bitnami/postgresql:11.8.0-debian-10-r72",
+		ContainerImage: containerImage,
 		Command:        []string{`/bin/bash`},
 		Args:           []string{"-c", " trap 'exit 0' SIGTERM;while true; do sleep 1; done"},
 		EnvVars: []v1.EnvVar{{
@@ -177,14 +182,14 @@ func PsqlPodConfig(password string) *pod.Config {
 }
 
 // EphemeralPodConfig config to use in ephemeral inline volume suite
-func EphemeralPodConfig(podName string, csiVolSrc v1.CSIVolumeSource) *pod.Config {
+func EphemeralPodConfig(podName string, csiVolSrc v1.CSIVolumeSource, containerImage string) *pod.Config {
 	return &pod.Config{
 		Name:            podName,
 		NamePrefix:      "pod-ephemeral-test-",
 		VolumeName:      "ephemeral-vol",
 		MountPath:       "/data",
 		ContainerName:   "prov-test",
-		ContainerImage:  "docker.io/centos:latest",
+		ContainerImage:  containerImage,
 		Command:         []string{`/bin/bash`},
 		Args:            []string{"-c", "trap 'exit 0' SIGTERM;while true; do sleep 1; done"},
 		CSIVolumeSource: csiVolSrc,
@@ -192,7 +197,7 @@ func EphemeralPodConfig(podName string, csiVolSrc v1.CSIVolumeSource) *pod.Confi
 }
 
 // VolumeMigrateStsConfig config to use in scaling suite
-func VolumeMigrateStsConfig(storageclass string, claimSize string, volumeNumber int, podNumber int32, podPolicy string) *statefulset.Config {
+func VolumeMigrateStsConfig(storageclass string, claimSize string, volumeNumber int, podNumber int32, podPolicy string, containerImage string) *statefulset.Config {
 	return &statefulset.Config{
 		VolumeNumber:        volumeNumber,
 		Replicas:            podNumber,
@@ -202,7 +207,7 @@ func VolumeMigrateStsConfig(storageclass string, claimSize string, volumeNumber 
 		PodManagementPolicy: podPolicy,
 		ClaimSize:           claimSize,
 		ContainerName:       "volume-migrate-test",
-		ContainerImage:      "docker.io/centos:latest",
+		ContainerImage:      containerImage,
 		NamePrefix:          "sts-volume-migrate-test",
 		Command:             []string{`/bin/bash`},
 		Args:                []string{"-c", "trap 'exit 0' SIGTERM;while true; do sleep 1; done"},

--- a/pkg/testcore/suites/functional-suites.go
+++ b/pkg/testcore/suites/functional-suites.go
@@ -482,6 +482,7 @@ type EphemeralVolumeSuite struct {
 	PodNumber        int
 	Driver           string
 	FSType           string
+	Image            string
 	VolumeAttributes map[string]string
 }
 
@@ -492,6 +493,11 @@ func (ep *EphemeralVolumeSuite) Run(ctx context.Context, storageClass string, cl
 	if ep.PodNumber <= 0 {
 		log.Info("Using default number of pods")
 		ep.PodNumber = 3
+	}
+
+	if ep.Image == "" {
+		log.Info("Using default image")
+		ep.Image = "docker.io/centos:latest"
 	}
 
 	log.Infof("Creating %s pods, each with 1 volumes", color.YellowString(strconv.Itoa(ep.PodNumber)))
@@ -510,7 +516,7 @@ func (ep *EphemeralVolumeSuite) Run(ctx context.Context, storageClass string, cl
 			name = ep.PodCustomName + "-" + strconv.Itoa(i)
 		}
 		// Create pod with ephemeral inline volume
-		podConf = testcore.EphemeralPodConfig(name, csiVolSrc)
+		podConf = testcore.EphemeralPodConfig(name, csiVolSrc, ep.Image)
 		podTmpl := podClient.MakeEphemeralPod(podConf)
 
 		pod := podClient.Create(ctx, podTmpl)
@@ -819,6 +825,7 @@ type CapacityTrackingSuite struct {
 	DriverNamespace string
 	StorageClass    string
 	VolumeSize      string
+	Image           string
 	PollInterval    time.Duration
 }
 
@@ -835,6 +842,12 @@ func (cts *CapacityTrackingSuite) Run(ctx context.Context, storageClass string, 
 	if sc.HasError() {
 		return delFunc, sc.GetError()
 	}
+
+	if cts.Image == "" {
+		log.Info("Using default image")
+		cts.Image = "docker.io/centos:latest"
+	}
+
 	if *sc.Object.VolumeBindingMode != storagev1.VolumeBindingWaitForFirstConsumer {
 		return delFunc, fmt.Errorf("%s storage class does not use late binding", color.YellowString(storageClass))
 	}
@@ -892,7 +905,7 @@ func (cts *CapacityTrackingSuite) Run(ctx context.Context, storageClass string, 
 		return delFunc, pvc.GetError()
 	}
 
-	podConf := testcore.CapacityTrackingPodConfig([]string{pvc.Object.Name}, podName)
+	podConf := testcore.CapacityTrackingPodConfig([]string{pvc.Object.Name}, podName, cts.Image)
 	podTmpl := clients.PodClient.MakePod(podConf)
 	pod := clients.PodClient.Create(ctx, podTmpl)
 	if pod.HasError() {

--- a/pkg/testcore/suites/helm-suites.go
+++ b/pkg/testcore/suites/helm-suites.go
@@ -37,6 +37,7 @@ type PostgresqlSuite struct {
 	ConfigPath        string
 	VolumeSize        string
 	EnableReplication bool
+	Image             string
 	SlaveReplicas     int
 }
 
@@ -45,6 +46,11 @@ func (ps *PostgresqlSuite) Run(ctx context.Context, storageClass string, clients
 	if ps.VolumeSize == "" {
 		log.Info("Using default volume size : 32Gi")
 		ps.VolumeSize = "32Gi"
+	}
+
+	if ps.Image == "" {
+		log.Info("Using default image")
+		ps.Image = "docker.io/bitnami/postgresql:11.8.0-debian-10-r72"
 	}
 
 	pvcClient := clients.PVCClient
@@ -86,7 +92,7 @@ func (ps *PostgresqlSuite) Run(ctx context.Context, storageClass string, clients
 		return delFunc, err
 	}
 
-	podconf := testcore.PsqlPodConfig(psqlPass)
+	podconf := testcore.PsqlPodConfig(psqlPass, ps.Image)
 	podTmpl := podClient.MakePod(podconf)
 
 	pod := podClient.Create(ctx, podTmpl).Sync(ctx)

--- a/pkg/testcore/suites/perf-suites.go
+++ b/pkg/testcore/suites/perf-suites.go
@@ -211,6 +211,7 @@ type ProvisioningSuite struct {
 	RawBlock      bool
 	VolAccessMode string
 	ROFlag        bool
+	Image         string
 }
 
 // Run executes provisioning test suite
@@ -229,6 +230,10 @@ func (ps *ProvisioningSuite) Run(ctx context.Context, storageClass string, clien
 	if ps.VolumeSize == "" {
 		log.Info("Using default volume size 3Gi")
 		ps.VolumeSize = "3Gi"
+	}
+	if ps.Image == "" {
+		log.Info("Using default image")
+		ps.Image = "docker.io/centos:latest"
 	}
 	ps.validateCustomPodName()
 
@@ -260,7 +265,7 @@ func (ps *ProvisioningSuite) Run(ctx context.Context, storageClass string, clien
 		}
 
 		// Create Pod, and attach PVC
-		podconf := testcore.ProvisioningPodConfig(pvcNameList, ps.PodCustomName)
+		podconf := testcore.ProvisioningPodConfig(pvcNameList, ps.PodCustomName, ps.Image)
 		if ps.RawBlock {
 			podconf.VolumeMode = pod.Block
 		}
@@ -355,6 +360,7 @@ type RemoteReplicationProvisioningSuite struct {
 	VolAccessMode    string
 	RemoteConfigPath string
 	NoFailover       bool
+	Image            string
 }
 
 // Run executes remote replication provisioning test suite
@@ -389,6 +395,10 @@ func (rrps *RemoteReplicationProvisioningSuite) Run(ctx context.Context, storage
 	if rrps.VolumeSize == "" {
 		log.Info("Using default volume size 3Gi")
 		rrps.VolumeSize = "3Gi"
+	}
+	if rrps.Image == "" {
+		log.Info("Using default image")
+		rrps.Image = "docker.io/centos:latest"
 	}
 
 	if rrps.RemoteConfigPath != "" && !isSingle {
@@ -462,7 +472,7 @@ func (rrps *RemoteReplicationProvisioningSuite) Run(ctx context.Context, storage
 	log.Info("Creating pod for each volume")
 	for _, name := range pvcNames {
 		// Create Pod, and attach PVC
-		podconf := testcore.ProvisioningPodConfig([]string{name}, "")
+		podconf := testcore.ProvisioningPodConfig([]string{name}, "", rrps.Image)
 		podTmpl := podClient.MakePod(podconf)
 
 		pod := podClient.Create(ctx, podTmpl).Sync(ctx)
@@ -665,7 +675,7 @@ func (rrps *RemoteReplicationProvisioningSuite) Run(ctx context.Context, storage
 		for _, pvcName := range pvcNameList {
 			log.Infof("Verifying data from pvc %s", pvcName)
 
-			podConf := testcore.ProvisioningPodConfig([]string{pvcName}, "")
+			podConf := testcore.ProvisioningPodConfig([]string{pvcName}, "", rrps.Image)
 			podTemp := remotePodClient.MakePod(podConf)
 
 			remotePod := remotePodClient.Create(ctx, podTemp).Sync(ctx)
@@ -726,7 +736,7 @@ func (rrps *RemoteReplicationProvisioningSuite) Run(ctx context.Context, storage
 		for _, pvcName := range pvcNameList {
 			log.Infof("Verifying data from pvc %s", pvcName)
 
-			podConf := testcore.ProvisioningPodConfig([]string{pvcName}, "")
+			podConf := testcore.ProvisioningPodConfig([]string{pvcName}, "", rrps.Image)
 			podTemp := remotePodClient.MakePod(podConf)
 
 			remotePod := remotePodClient.Create(ctx, podTemp).Sync(ctx)
@@ -869,6 +879,7 @@ type ScalingSuite struct {
 	GradualScaleDown bool
 	PodPolicy        string
 	VolumeSize       string
+	Image            string
 }
 
 // Run executes scaling test suite
@@ -892,8 +903,12 @@ func (ss *ScalingSuite) Run(ctx context.Context, storageClass string, clients *k
 		log.Info("Using default volume size 3Gi")
 		ss.VolumeSize = "3Gi"
 	}
+	if ss.Image == "" {
+		log.Info("Using default image")
+		ss.Image = "docker.io/centos:latest"
+	}
 
-	stsconf := testcore.ScalingStsConfig(storageClass, ss.VolumeSize, ss.VolumeNumber, ss.PodPolicy)
+	stsconf := testcore.ScalingStsConfig(storageClass, ss.VolumeSize, ss.VolumeNumber, ss.PodPolicy, ss.Image)
 	stsTmpl := stsClient.MakeStatefulSet(stsconf)
 
 	// Creating new statefulset
@@ -997,6 +1012,7 @@ type VolumeIoSuite struct {
 	VolumeSize   string
 	ChainNumber  int
 	ChainLength  int
+	Image        string
 }
 
 // Run executes volume IO test suite
@@ -1019,6 +1035,11 @@ func (vis *VolumeIoSuite) Run(ctx context.Context, storageClass string, clients 
 	if vis.ChainLength <= 0 {
 		log.Info("Using default length of chains")
 		vis.ChainLength = 5
+	}
+
+	if vis.Image == "" {
+		log.Info("Using default image")
+		vis.Image = "docker.io/centos:latest"
 	}
 
 	firstConsumer, err := shouldWaitForFirstConsumer(ctx, storageClass, pvcClient)
@@ -1056,7 +1077,7 @@ func (vis *VolumeIoSuite) Run(ctx context.Context, storageClass string, clients 
 
 		pvName := gotPvc.Spec.VolumeName
 		// Create Pod, and attach PVC
-		podconf := testcore.IoWritePodConfig(pvcNameList, "")
+		podconf := testcore.IoWritePodConfig(pvcNameList, "", vis.Image)
 		podTmpl := podClient.MakePod(podconf)
 		errs.Go(func() error {
 			for i := 0; i < vis.ChainLength; i++ {
@@ -1168,6 +1189,7 @@ type VolumeGroupSnapSuite struct {
 	ReclaimPolicy   string
 	VolumeNumber    int
 	Driver          string
+	Image           string
 }
 
 // Run executes volume group snap test suite
@@ -1178,6 +1200,11 @@ func (vgs *VolumeGroupSnapSuite) Run(ctx context.Context, storageClass string, c
 	if vgs.VolumeSize == "" {
 		log.Info("Using default volume size : 3Gi")
 		vgs.VolumeSize = "3Gi"
+	}
+
+	if vgs.Image == "" {
+		log.Info("Using default image")
+		vgs.Image = "docker.io/centos:latest"
 	}
 
 	pvcClient := clients.PVCClient
@@ -1214,7 +1241,7 @@ func (vgs *VolumeGroupSnapSuite) Run(ctx context.Context, storageClass string, c
 	}
 
 	// Create Pod, and attach PVC
-	podconf := testcore.IoWritePodConfig(pvcNameList, "")
+	podconf := testcore.IoWritePodConfig(pvcNameList, "", vgs.Image)
 	podTmpl := podClient.MakePod(podconf)
 
 	writerPod := podClient.Create(ctx, podTmpl).Sync(ctx)
@@ -1309,6 +1336,7 @@ type SnapSuite struct {
 	CustomSnapName     string
 	AccessModeOriginal string
 	AccessModeRestored string
+	Image              string
 }
 
 // Run executes snap test suite
@@ -1321,6 +1349,10 @@ func (ss *SnapSuite) Run(ctx context.Context, storageClass string, clients *k8sc
 	if ss.VolumeSize == "" {
 		log.Info("Using default volume size : 3Gi")
 		ss.VolumeSize = "3Gi"
+	}
+	if ss.Image == "" {
+		log.Info("Using default image")
+		ss.Image = "docker.io/centos:latest"
 	}
 
 	result := validateCustomSnapName(ss.CustomSnapName, ss.SnapAmount)
@@ -1368,7 +1400,7 @@ func (ss *SnapSuite) Run(ctx context.Context, storageClass string, clients *k8sc
 	}
 
 	// Create Pod, and attach PVC
-	podconf := testcore.IoWritePodConfig(pvcNameList, snappodname)
+	podconf := testcore.IoWritePodConfig(pvcNameList, snappodname, ss.Image)
 	podTmpl := podClient.MakePod(podconf)
 
 	file := fmt.Sprintf("%s0/writer-%d.data", podconf.MountPath, 0)
@@ -1498,7 +1530,7 @@ func (ss *SnapSuite) Run(ctx context.Context, storageClass string, clients *k8sc
 
 	// Create Pod, and attach PVC from snapshot
 
-	podRestored := testcore.IoWritePodConfig(pvcFromSnapNameList, pvcRestored.Object.Name+"-pod")
+	podRestored := testcore.IoWritePodConfig(pvcFromSnapNameList, pvcRestored.Object.Name+"-pod", ss.Image)
 	podTmplRestored := podClient.MakePod(podRestored)
 
 	writerPod = podClient.Create(ctx, podTmplRestored).Sync(ctx)
@@ -1622,6 +1654,7 @@ type ReplicationSuite struct {
 	VolumeSize   string
 	PodNumber    int
 	SnapClass    string
+	Image        string
 }
 
 // Run executes replication test suite
@@ -1642,6 +1675,10 @@ func (rs *ReplicationSuite) Run(ctx context.Context, storageClass string, client
 	if rs.VolumeSize == "" {
 		log.Info("Using default volume size : 3Gi")
 		rs.VolumeSize = "3Gi"
+	}
+	if rs.Image == "" {
+		log.Info("Using default image")
+		rs.Image = "docker.io/centos:latest"
 	}
 
 	log.Infof("Creating %s pods, each with %s volumes", color.YellowString(strconv.Itoa(rs.PodNumber)),
@@ -1664,7 +1701,7 @@ func (rs *ReplicationSuite) Run(ctx context.Context, storageClass string, client
 		}
 
 		// Create Pod, and attach PVC
-		podconf := testcore.ProvisioningPodConfig(pvcNameList, "")
+		podconf := testcore.ProvisioningPodConfig(pvcNameList, "", rs.Image)
 		podTmpl := podClient.MakePod(podconf)
 
 		pod := podClient.Create(ctx, podTmpl)
@@ -1772,7 +1809,7 @@ func (rs *ReplicationSuite) Run(ctx context.Context, storageClass string, client
 			pvcNameList[j] = pvc.Object.Name
 		}
 		// Create Pod, and attach restored PVC
-		podconf := testcore.ProvisioningPodConfig(pvcNameList, "")
+		podconf := testcore.ProvisioningPodConfig(pvcNameList, "", rs.Image)
 		podTmpl := podClient.MakePod(podconf)
 
 		pod := podClient.Create(ctx, podTmpl)
@@ -1891,6 +1928,7 @@ type VolumeExpansionSuite struct {
 	ExpandedSize string
 	Description  string
 	AccessMode   string
+	Image        string
 }
 
 // Run executes volume expansion test suite
@@ -1905,6 +1943,10 @@ func (ves *VolumeExpansionSuite) Run(ctx context.Context, storageClass string, c
 	if ves.PodNumber <= 0 {
 		log.Info("Using default number of volumes")
 		ves.PodNumber = 1
+	}
+	if ves.Image == "" {
+		log.Info("Using default image")
+		ves.Image = "docker.io/centos:latest"
 	}
 
 	log.Infof("Creating %s pods, each with %s volumes of size (%s)", color.YellowString(strconv.Itoa(ves.PodNumber)),
@@ -1930,7 +1972,7 @@ func (ves *VolumeExpansionSuite) Run(ctx context.Context, storageClass string, c
 		}
 
 		// Create Pod, and attach PVC
-		podconf := testcore.ProvisioningPodConfig(pvcNameList, "")
+		podconf := testcore.ProvisioningPodConfig(pvcNameList, "", ves.Image)
 		if ves.IsBlock {
 			podconf.VolumeMode = pod.Block
 		}
@@ -2165,6 +2207,7 @@ type VolumeHealthMetricsSuite struct {
 	Description  string
 	AccessMode   string
 	Namespace    string
+	Image        string
 }
 
 // FindDriverLogs executes command and returns the output
@@ -2194,6 +2237,10 @@ func (vh *VolumeHealthMetricsSuite) Run(ctx context.Context, storageClass string
 		log.Info("Using default number of pods")
 		vh.PodNumber = 1
 	}
+	if vh.Image == "" {
+		log.Info("Using default image")
+		vh.Image = "docker.io/centos:latest"
+	}
 
 	//Create a PVC
 	vcconf := testcore.VolumeCreationConfig(storageClass, vh.VolumeSize, "", vh.AccessMode)
@@ -2205,7 +2252,7 @@ func (vh *VolumeHealthMetricsSuite) Run(ctx context.Context, storageClass string
 	PVCNamespace := pvcClient.Namespace
 
 	// Create Pod, and attach PVC
-	podconf := testcore.VolumeHealthPodConfig([]string{pvc.Object.Name}, "")
+	podconf := testcore.VolumeHealthPodConfig([]string{pvc.Object.Name}, "", vh.Image)
 	podTmpl := podClient.MakePod(podconf)
 
 	pod := podClient.Create(ctx, podTmpl)
@@ -2381,6 +2428,7 @@ type CloneVolumeSuite struct {
 	CustomPodName string
 	Description   string
 	AccessMode    string
+	Image         string
 }
 
 // Run executes clone volume test suite
@@ -2399,6 +2447,10 @@ func (cs *CloneVolumeSuite) Run(ctx context.Context, storageClass string, client
 	if cs.VolumeSize == "" {
 		log.Info("Using default volume size:3Gi")
 		cs.VolumeSize = "3Gi"
+	}
+	if cs.Image == "" {
+		log.Info("Using default image")
+		cs.Image = "docker.io/centos:latest"
 	}
 	clonedVolName := ""
 	result := validateCustomName(cs.CustomPvcName, cs.VolumeNumber)
@@ -2438,7 +2490,7 @@ func (cs *CloneVolumeSuite) Run(ctx context.Context, storageClass string, client
 		}
 
 		// Create Pod, and attach PVC
-		podconf := testcore.ProvisioningPodConfig(pvcNameList, cs.CustomPodName)
+		podconf := testcore.ProvisioningPodConfig(pvcNameList, cs.CustomPodName, cs.Image)
 		podTmpl := podClient.MakePod(podconf)
 
 		pod := podClient.Create(ctx, podTmpl)
@@ -2468,7 +2520,7 @@ func (cs *CloneVolumeSuite) Run(ctx context.Context, storageClass string, client
 			pvcNameList[j] = pvc.Object.Name
 		}
 		// Create Pod, and attach restored PVC
-		podconf := testcore.ProvisioningPodConfig(pvcNameList, clonedPodName)
+		podconf := testcore.ProvisioningPodConfig(pvcNameList, clonedPodName, cs.Image)
 		podTmpl := podClient.MakePod(podconf)
 
 		pod := podClient.Create(ctx, podTmpl)
@@ -2545,6 +2597,7 @@ type MultiAttachSuite struct {
 	Description string
 	AccessMode  string
 	VolumeSize  string
+	Image       string
 }
 
 // Run executes multi attach test suite
@@ -2557,6 +2610,10 @@ func (mas *MultiAttachSuite) Run(ctx context.Context, storageClass string, clien
 	if mas.PodNumber <= 0 {
 		log.Info("Using default number of pods")
 		mas.PodNumber = 2
+	}
+	if mas.Image == "" {
+		log.Info("Using default image")
+		mas.Image = "docker.io/centos:latest"
 	}
 
 	log.Info("Creating Volume")
@@ -2576,7 +2633,7 @@ func (mas *MultiAttachSuite) Run(ctx context.Context, storageClass string, clien
 
 	log.Info("Attaching Volume to original pod")
 	// Create Pod, and attach PVC
-	podconf := testcore.MultiAttachPodConfig([]string{pvc.Object.Name})
+	podconf := testcore.MultiAttachPodConfig([]string{pvc.Object.Name}, mas.Image)
 
 	if mas.RawBlock {
 		podconf.VolumeMode = pod.Block
@@ -2809,6 +2866,7 @@ type BlockSnapSuite struct {
 	VolumeSize  string
 	Description string
 	AccessMode  string
+	Image       string
 }
 
 // Run executes block snapshot test suite
@@ -2817,6 +2875,10 @@ func (bss *BlockSnapSuite) Run(ctx context.Context, storageClass string, clients
 	if bss.VolumeSize == "" {
 		log.Info("Using default volume size : 3Gi")
 		bss.VolumeSize = "3Gi"
+	}
+	if bss.Image == "" {
+		log.Info("Using default image")
+		bss.Image = "docker.io/centos:latest"
 	}
 	pvcClient := clients.PVCClient
 	podClient := clients.PodClient
@@ -2842,7 +2904,7 @@ func (bss *BlockSnapSuite) Run(ctx context.Context, storageClass string, clients
 	}
 
 	// Create Pod, and attach PVC
-	podconf := testcore.BlockSnapPodConfig(pvcNameList)
+	podconf := testcore.BlockSnapPodConfig(pvcNameList, bss.Image)
 	podTmpl := podClient.MakePod(podconf)
 
 	file := fmt.Sprintf("%s0/writer-%d.data", podconf.MountPath, 0)
@@ -2948,7 +3010,7 @@ func (bss *BlockSnapSuite) Run(ctx context.Context, storageClass string, clients
 	}
 
 	// Create Pod, and attach PVC from snapshot
-	podRestored := testcore.BlockSnapPodConfig([]string{pvcRestored.Object.Name})
+	podRestored := testcore.BlockSnapPodConfig([]string{pvcRestored.Object.Name}, bss.Image)
 	podRestored.VolumeMode = pod.Block
 	podTmplRestored := podClient.MakePod(podRestored)
 
@@ -3098,6 +3160,7 @@ type VolumeMigrateSuite struct {
 	VolumeNumber int
 	PodNumber    int
 	Flag         bool
+	Image        string
 }
 
 // Run executes volume migrate test suite
@@ -3111,6 +3174,10 @@ func (vms *VolumeMigrateSuite) Run(ctx context.Context, storageClass string, cli
 	if vms.PodNumber <= 0 {
 		log.Println("Using default number of pods")
 		vms.PodNumber = 3
+	}
+	if vms.Image == "" {
+		log.Info("Using default image")
+		vms.Image = "docker.io/centos:latest"
 	}
 
 	log.Println("Volumes:", vms.VolumeNumber, "pods:", vms.PodNumber)
@@ -3130,7 +3197,7 @@ func (vms *VolumeMigrateSuite) Run(ctx context.Context, storageClass string, cli
 		return delFunc, targetSC.GetError()
 	}
 
-	stsConf := testcore.VolumeMigrateStsConfig(storageClass, "1Gi", vms.VolumeNumber, int32(vms.PodNumber), "")
+	stsConf := testcore.VolumeMigrateStsConfig(storageClass, "1Gi", vms.VolumeNumber, int32(vms.PodNumber), "", vms.Image)
 	stsTmpl := stsClient.MakeStatefulSet(stsConf)
 	// Creating Statefulset
 	log.Println("Creating Statefulset")
@@ -3271,7 +3338,7 @@ func (vms *VolumeMigrateSuite) Run(ctx context.Context, storageClass string, cli
 		podClient.Delete(ctx, &pod)
 	}
 
-	newStsConf := testcore.VolumeMigrateStsConfig(vms.TargetSC, "1Gi", vms.VolumeNumber, int32(vms.PodNumber), "")
+	newStsConf := testcore.VolumeMigrateStsConfig(vms.TargetSC, "1Gi", vms.VolumeNumber, int32(vms.PodNumber), "", vms.Image)
 	newStsTmpl := stsClient.MakeStatefulSet(newStsConf)
 	// Creating new Statefulset
 	log.Println("Creating new Statefulset")


### PR DESCRIPTION
# Description
This PR allows cert-csi to use custom images for creating containers by passing an image config YAML file as an argument. The YAML file should have linux(test) and postgres images name with their corresponding image URL. For example:

```
images:
  - test: "docker.io/centos:centos7"
    postgres: "docker.io/bitnami/postgresql:11.8.0-debian-10-r72"
```

To use this feature, run cert-csi with the option --image-config /path/to/config.yaml along with any other arguments.
# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1059|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Built binary and executed unit tests
![image](https://github.com/dell/cert-csi/assets/120644626/531c0ff3-acd8-48b2-8af8-716e84426993)

- [x] Executed the cert-csi to verify whether the provided image was utilized in the container build process
![image](https://github.com/dell/cert-csi/assets/120644626/8c8bdbe3-6996-4bcc-93bd-c99e8daea067)

