### PR TITLE
Use go base image

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -14,7 +14,7 @@ jobs:
     name: golangci-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: "1.20"
           cache: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,9 @@
 #
 
 ARG BASEIMAGE
+ARG GOIMAGE
 
-FROM golang:1.20 as build-env
+FROM $GOIMAGE as build-env
 
 WORKDIR /app/cert-csi/
 COPY go.mod go.sum ./

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ build:
 
 docker: download-csm-common
 	$(eval include csm-common.mk)
-	$(BUILDER) build -t cert-csi:latest --build-arg BASEIMAGE=$(DEFAULT_BASEIMAGE) .
+	$(BUILDER) build -t cert-csi:latest --build-arg BASEIMAGE=$(DEFAULT_BASEIMAGE) --build-arg GOIMAGE=$(DEFAULT_GOIMAGE) .
 
 # build-statically-linked : used for building a standalone binary with statically linked glibc
 # this command should be used when building the binary for distributing it to customer/user


### PR DESCRIPTION
# Description
Changes to point to Default go image version in common.mk file.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1098 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
![image](https://github.com/dell/cert-csi/assets/92028646/3da6c5e9-09de-451c-8c65-ee42f4b681fa)

