### PR TITLE
Security updates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/distribution/reference v0.5.0 // indirect
 	github.com/docker/cli v25.0.1+incompatible // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect
-	github.com/docker/docker v26.1.4+incompatible // indirect
+	github.com/docker/docker v27.1.1+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.7.0 // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
 	github.com/docker/go-metrics v0.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -128,8 +128,8 @@ github.com/docker/cli v25.0.1+incompatible h1:mFpqnrS6Hsm3v1k7Wa/BO23oz0k121MTbT
 github.com/docker/cli v25.0.1+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=
 github.com/docker/distribution v2.8.3+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v26.1.4+incompatible h1:vuTpXDuoga+Z38m1OZHzl7NKisKWaWlhjQk7IDPSLsU=
-github.com/docker/docker v26.1.4+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v27.1.1+incompatible h1:hO/M4MtV36kzKldqnA37IWhebRA+LnqqcqDja6kVaKY=
+github.com/docker/docker v27.1.1+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.7.0 h1:xtCHsjxogADNZcdv1pKUHXryefjlVRqWqIhk/uXJp0A=
 github.com/docker/docker-credential-helpers v0.7.0/go.mod h1:rETQfLdHNT3foU5kuNkFR1R1V12OJRRO5lzt2D1b5X0=
 github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj1Br63c=

--- a/pkg/utils/k8s_utils_test.go
+++ b/pkg/utils/k8s_utils_test.go
@@ -328,10 +328,10 @@ func TestExecuteE2ECommand(t *testing.T) {
 		{
 			name: "execute with proper arguments",
 			args: args{
-				args: []string{"-kubeconfig", "/root/.kube/config", "-storage.testdriver", "testdata/config-nfs.yaml", "--ginkgo.skip", "*"},
+				args: []string{"-kubeconfig", "/root/.kube/config", "-storage.testdriver", "testdata/config-nfs.yaml", "--ginkgo.skip", ".*"},
 				ch:   cha,
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
# Description
- Security updates
- Fixes TestExecuteE2ECommand UT
```
=== RUN   TestExecuteE2ECommand/execute_with_proper_arguments
time="2024-08-05T19:49:36Z" level=info msg="e2e command arguments are: [-kubeconfig /root/.kube/config -storage.testdriver testdata/config-nfs.yaml --ginkgo.skip *]"
Aug  5 19:49:36.468: INFO: Driver loaded from path [testdata/config-nfs.yaml]: &{DriverInfo:{Name:csi-powerstore.dellemc.com InTreePluginName: FeatureTag: MaxFileSize:0 SupportedSizeRange:{Max: Min:3Gi} SupportedFsType:map[:{} nfs:{}] SupportedMountOption:map[] RequiredMountOption:map[] Capabilities:map[block:false capacity:true controllerExpansion:true exec:true fsGroup:true multipods:true nodeExpansion:false offlineExpansion:true onlineExpansion:true persistence:true pvcDataSource:true readWriteOncePod:true snapshotDataSource:true topology:true volumeLimits:false] RequiredAccessModes:[] TopologyKeys:[csi-powerstore.dellemc.com/10.10.10.10-nfs csi-powerstore.dellemc.com/10.10.10.10-iscsi] NumAllowedTopologies:0 StressTestOptions:0xc0001370c0 VolumeSnapshotStressTestOptions:0xc000137100 PerformanceTestOptions:0xc000bf82b8} StorageClass:{FromName:false FromFile: FromExistingClassName:powerstore-nfs} SnapshotClass:{FromName:false FromFile: FromExistingClassName:powerstore-snapclass} InlineVolumes:[{Attributes:map[arrayID:myarrayid nasName:team-nas protocol:NFS size:5Gi] Shared:true ReadOnly:false}] ClientNodeName: Timeouts:map[]}
Aug  5 19:49:36.468: INFO: The --provider flag is not set. Continuing as if --provider=skeleton had been used.
I0805 19:49:36.468701   32566 e2e.go:116] Starting e2e run "432cf38e-28cb-4627-bf3d-b426e6cedee6" on Ginkgo node 1
Aug  5 19:49:36.483: INFO: Enabling in-tree volume drivers
--- FAIL: TestE2E (0.22s)
panic: regexp: Compile(`*`): error parsing regexp: missing argument to repetition operator: `*` [recovered]
        panic: regexp: Compile(`*`): error parsing regexp: missing argument to repetition operator: `*`

goroutine 83 [running]:
testing.tRunner.func1.2({0x64ff8a0, 0xc001004070})
        /usr/local/go/src/testing/testing.go:1396 +0x24e
testing.tRunner.func1()
        /usr/local/go/src/testing/testing.go:1399 +0x39f
panic({0x64ff8a0, 0xc001004070})
        /usr/local/go/src/runtime/panic.go:884 +0x212
regexp.MustCompile({0x7fff153d22ea, 0x1})
        /usr/local/go/src/regexp/regexp.go:319 +0xbb
k8s.io/kubernetes/vendor/github.com/onsi/ginkgo/v2/internal.ApplyFocusToSpecs({0xc003200000, 0x1ca7, 0x7c0e998?}, {0x7399601, _}, {_, _, _}, {0x66b12cd0, 0x1, ...})
        vendor/github.com/onsi/ginkgo/v2/internal/focus.go:108 +0x753
k8s.io/kubernetes/vendor/github.com/onsi/ginkgo/v2/internal.(*Suite).Run(_, {_, _}, {_, _, _}, {_, _}, _, {0x7c60e28, ...}, ...)
        vendor/github.com/onsi/ginkgo/v2/internal/suite.go:72 +0x105
k8s.io/kubernetes/vendor/github.com/onsi/ginkgo/v2.RunSpecs({0x7c2dd80, 0xc000953380}, {0x7399601, 0x14}, {0xc0003099a8?, 0x2, 0x0?})
        vendor/github.com/onsi/ginkgo/v2/core_dsl.go:280 +0xa13
k8s.io/kubernetes/test/e2e.RunE2ETests(0xc000953380?)
        test/e2e/e2e.go:117 +0x6bc
k8s.io/kubernetes/test/e2e.TestE2E(0x0?)
        test/e2e/e2e_test.go:139 +0x19
testing.tRunner(0xc000953380, 0x761c1f0)
        /usr/local/go/src/testing/testing.go:1446 +0x10b
created by testing.(*T).Run
        /usr/local/go/src/testing/testing.go:1493 +0x35f
--- PASS: TestExecuteE2ECommand (0.42s)
    --- PASS: TestExecuteE2ECommand/execute_with_proper_arguments (0.42s)

```
# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] make test
[unit-test.txt](https://github.com/user-attachments/files/16502102/unit-test.txt)
