### PR TITLE
Fixing  cert-csi failure for k8s environment

### DIFF
--- a/pkg/k8sclient/resources/pod/pod.go
+++ b/pkg/k8sclient/resources/pod/pod.go
@@ -747,8 +747,9 @@ func (pod *Pod) IsInPendingState(ctx context.Context) error {
 	}
 	return nil
 }
+
 func IsOCP() (bool, error) {
-	var isOCP = false
+	isOCP := false
 	cmd := exec.Command("oc", "get", "clusterversion")
 
 	// Run the command and capture the output

--- a/pkg/k8sclient/resources/pod/pod.go
+++ b/pkg/k8sclient/resources/pod/pod.go
@@ -22,7 +22,9 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"os/exec"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/dell/cert-csi/pkg/utils"
@@ -151,9 +153,27 @@ func (c *Client) MakePod(config *Config) *v1.Pod {
 		}
 		volumes = append(volumes, volume)
 	}
-	allowPrivilegeEscalation := false
-	runAsNonRoot := true
-	seccompProfileType := v1.SeccompProfileTypeRuntimeDefault
+	isOCP, _ := IsOCP()
+	securityContext := &v1.SecurityContext{
+		Capabilities: &v1.Capabilities{
+			Add: config.Capabilities,
+		},
+	}
+	if isOCP {
+		securityContext = &v1.SecurityContext{
+			AllowPrivilegeEscalation: func(b bool) *bool { return &b }(false),
+			Capabilities: &v1.Capabilities{
+				Drop: []v1.Capability{
+					"ALL",
+				},
+				Add: config.Capabilities,
+			},
+			RunAsNonRoot: func(b bool) *bool { return &b }(true),
+			SeccompProfile: &v1.SeccompProfile{
+				Type: v1.SeccompProfileTypeRuntimeDefault,
+			},
+		}
+	}
 	container := v1.Container{
 		Name:            config.ContainerName,
 		Image:           config.ContainerImage,
@@ -161,17 +181,7 @@ func (c *Client) MakePod(config *Config) *v1.Pod {
 		Args:            config.Args,
 		Env:             config.EnvVars,
 		ImagePullPolicy: "IfNotPresent",
-		SecurityContext: &v1.SecurityContext{
-			AllowPrivilegeEscalation: &allowPrivilegeEscalation,
-			Capabilities: &v1.Capabilities{
-				Drop: []v1.Capability{"ALL"},
-				Add:  config.Capabilities,
-			},
-			RunAsNonRoot: &runAsNonRoot,
-			SeccompProfile: &v1.SeccompProfile{
-				Type: seccompProfileType,
-			},
-		},
+		SecurityContext: securityContext,
 	}
 
 	container.VolumeMounts = volumeMounts
@@ -562,9 +572,28 @@ func (c *Client) MakeEphemeralPod(config *Config) *v1.Pod {
 		},
 	}
 	volumes = append(volumes, volume)
-	allowPrivilegeEscalation := false
-	runAsNonRoot := true
-	seccompProfileType := v1.SeccompProfileTypeRuntimeDefault
+	isOCP, _ := IsOCP()
+
+	securityContext := &v1.SecurityContext{
+		Capabilities: &v1.Capabilities{
+			Add: config.Capabilities,
+		},
+	}
+	if isOCP {
+		securityContext = &v1.SecurityContext{
+			AllowPrivilegeEscalation: func(b bool) *bool { return &b }(false),
+			Capabilities: &v1.Capabilities{
+				Drop: []v1.Capability{
+					"ALL",
+				},
+				Add: config.Capabilities,
+			},
+			RunAsNonRoot: func(b bool) *bool { return &b }(true),
+			SeccompProfile: &v1.SeccompProfile{
+				Type: v1.SeccompProfileTypeRuntimeDefault,
+			},
+		}
+	}
 	container := v1.Container{
 		Name:            config.ContainerName,
 		Image:           config.ContainerImage,
@@ -573,17 +602,7 @@ func (c *Client) MakeEphemeralPod(config *Config) *v1.Pod {
 		Env:             config.EnvVars,
 		VolumeMounts:    volumeMounts,
 		ImagePullPolicy: "IfNotPresent",
-		SecurityContext: &v1.SecurityContext{
-			AllowPrivilegeEscalation: &allowPrivilegeEscalation,
-			Capabilities: &v1.Capabilities{
-				Drop: []v1.Capability{"ALL"},
-				Add:  config.Capabilities,
-			},
-			RunAsNonRoot: &runAsNonRoot,
-			SeccompProfile: &v1.SeccompProfile{
-				Type: seccompProfileType,
-			},
-		},
+		SecurityContext: securityContext,
 	}
 
 	ObjMeta := metav1.ObjectMeta{
@@ -727,4 +746,24 @@ func (pod *Pod) IsInPendingState(ctx context.Context) error {
 		return fmt.Errorf("%s pod is in %s state", updatedPod.Name, updatedPod.Status.Phase)
 	}
 	return nil
+}
+func IsOCP() (bool, error) {
+	var isOCP = false
+	cmd := exec.Command("oc", "get", "clusterversion")
+
+	// Run the command and capture the output
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		// Return false and the error encountered while executing the command
+		return false, err
+	}
+	outputStr := string(output)
+	lines := strings.Split(outputStr, "\n")
+	for _, line := range lines {
+		if strings.Contains(line, "Cluster version") {
+			isOCP = true
+			break
+		}
+	}
+	return isOCP, nil
 }


### PR DESCRIPTION
# Description
Cert-csi failing in k8s environment with error: container has runAsNonRoot and image will run as root

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1652 |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [X] Ran cert csi in k8s 1.32 for powerscale driver
[powerscale_cert-csi_test.txt](https://github.com/user-attachments/files/18252109/powerscale_cert-csi_test.txt)

- [X] Ran e2e for unity in ocp cluster
[unity_e2e.txt](https://github.com/user-attachments/files/18252112/unity_e2e.txt)
