### PR TITLE
Update go.mod file to get around dependency issue with k8s.io/kubernetes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ replace (
 	k8s.io/externaljwt => k8s.io/externaljwt v1.31.2
 	k8s.io/kube-aggregator => k8s.io/kube-aggregator v1.31.2
 	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v1.31.2
-	k8s.io/kube-proxy => k8s.io/kube-controller-manager v1.31.2
+	k8s.io/kube-proxy => k8s.io/kube-proxy v1.31.2
 	k8s.io/kube-scheduler => k8s.io/kube-scheduler v1.31.2
 	k8s.io/kubelet => k8s.io/kubelet v1.31.2
 	k8s.io/mount-utils => k8s.io/mount-utils v1.31.2

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,25 @@ require (
 	sigs.k8s.io/yaml v1.4.0
 )
 
+replace (
+	k8s.io/cloud-provider => k8s.io/cloud-provider v1.31.2
+	k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v1.31.2
+	k8s.io/controller-manager => k8s.io/controller-manager v1.31.2
+	k8s.io/cri-client => k8s.io/cri-client v1.31.2
+	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v1.31.2
+	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v1.31.2
+	k8s.io/endpointslice => k8s.io/endpointslice v1.31.2
+	k8s.io/externaljwt => k8s.io/externaljwt v1.31.2
+	k8s.io/kube-aggregator => k8s.io/kube-aggregator v1.31.2
+	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v1.31.2
+	k8s.io/kube-proxy => k8s.io/kube-controller-manager v1.31.2
+	k8s.io/kube-scheduler => k8s.io/kube-scheduler v1.31.2
+	k8s.io/kubelet => k8s.io/kubelet v1.31.2
+	k8s.io/mount-utils => k8s.io/mount-utils v1.31.2
+	k8s.io/pod-security-admission => k8s.io/pod-security-admission v1.31.2
+	k8s.io/sample-apiserver => k8s.io/sample-apiserver v1.31.2
+)
+
 require (
 	git.sr.ht/~sbinet/gg v0.5.0 // indirect
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230811130428-ced1acdcaa24 // indirect

--- a/pkg/utils/k8s_utils_test.go
+++ b/pkg/utils/k8s_utils_test.go
@@ -20,6 +20,7 @@ package utils
 
 import (
 	"flag"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -296,7 +297,7 @@ func TestBuildE2eCommand(t *testing.T) {
 		{
 			name:    "send good config file",
 			args:    args{ctx: x2},
-			want:    []string{"-kubeconfig", "/root/.kube/config", "-storage.testdriver", "testdata/config-nfs.yaml", "--ginkgo.junit-report", "/root/reports/execution_powerstore-nfs.xml"},
+			want:    []string{"-kubeconfig", "/root/.kube/config", "-storage.testdriver", "testdata/config-nfs.yaml", "--ginkgo.junit-report", fmt.Sprintf("%s/reports/execution_powerstore-nfs.xml", Home)},
 			wantErr: false,
 		},
 	}


### PR DESCRIPTION
# Description
Update go.mod file to get around dependency issue with k8s.io/kubernetes.  As per https://github.com/kubernetes/kubernetes/issues/79384, use of packages within the k8s.io/kubernetes module as a library/dependency is unsupported and not recommended.  The modules intended to be consumed as libraries are published with go.mod files that do not require any replace directives.  The issue is seen when trying to run "go mod list -m all".  To work around this issue, specific versions of each k8s.io/kubernetes library/dependency must be called out in a replace block, which is what this PR does.

Also fixed a failing test in pkg/utils/k8s_utils_test.go

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- Executed 'make build'

No errors: go build -ldflags "-s -w" ./cmd/cert-csi

- Executed 'make test'

All tests passed - as shown in the results of the PR check.