### PR TITLE
Filtering get topology count for specific sc key bug fix

### DIFF
--- a/pkg/testcore/suites/functional-suites_test.go
+++ b/pkg/testcore/suites/functional-suites_test.go
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright © 2024 Dell Inc. or its subsidiaries. All Rights Reserved.
+ * Copyright © 2025 Dell Inc. or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/testcore/suites/functional-suites_test.go
+++ b/pkg/testcore/suites/functional-suites_test.go
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright © 2022-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+ * Copyright © 2024 Dell Inc. or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/testcore/suites/functional-suites_test.go
+++ b/pkg/testcore/suites/functional-suites_test.go
@@ -1,0 +1,69 @@
+/*
+ *
+ * Copyright © 2022-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/*
+ *
+ * Copyright © 2022-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+ package suites
+
+ import (
+	 "errors"
+	 "testing"
+ 
+	 "github.com/stretchr/testify/assert"
+ )
+ 
+ func TestGetTopologyCount(t *testing.T) {
+	 // Test case: Empty topology keys
+	 FindDriverLogs = func(exe []string) (string, error) {
+		 return "", nil
+	 }
+	 topologyCount, err := getTopologyCount([]string{})
+	 assert.NoError(t, err)
+	 assert.Equal(t, 0, topologyCount)
+ 
+	 // Test case: Non-empty topology keys
+ 
+	 FindDriverLogs = func(exe []string) (string, error) {
+		 var keys = "Topology Keys: [csi-powerstore.dellemc.com/10.230.24.67-iscsi csi-powerstore.dellemc.com/10.230.24.67-nfs]"
+		 return keys, nil
+	 }
+	 topologyCount, err = getTopologyCount([]string{"csi-powerstore.dellemc.com/10.230.24.67-iscsi"})
+	 assert.NoError(t, err)
+	 assert.Equal(t, 1, topologyCount)
+ 
+	 // Test case: Error in FindDriverLogs
+	 FindDriverLogs = func(exe []string) (string, error) {
+		 return "", errors.New("error in FindDriverLogs")
+	 }
+	 type FindDriverLogs func(url string) string
+	 topologyCount, err = getTopologyCount([]string{})
+	 assert.Error(t, err)
+	 assert.Equal(t, 0, topologyCount)
+ }
+ 

--- a/pkg/testcore/suites/functional-suites_test.go
+++ b/pkg/testcore/suites/functional-suites_test.go
@@ -13,57 +13,40 @@
  * limitations under the License.
  *
  */
+package suites
 
-/*
- *
- * Copyright © 2022-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *      http://www.apache.org/licenses/LICENSE-2.0
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- */
- package suites
+import (
+	"errors"
+	"testing"
 
- import (
-	 "errors"
-	 "testing"
- 
-	 "github.com/stretchr/testify/assert"
- )
- 
- func TestGetTopologyCount(t *testing.T) {
-	 // Test case: Empty topology keys
-	 FindDriverLogs = func(exe []string) (string, error) {
-		 return "", nil
-	 }
-	 topologyCount, err := getTopologyCount([]string{})
-	 assert.NoError(t, err)
-	 assert.Equal(t, 0, topologyCount)
- 
-	 // Test case: Non-empty topology keys
- 
-	 FindDriverLogs = func(exe []string) (string, error) {
-		 var keys = "Topology Keys: [csi-powerstore.dellemc.com/10.230.24.67-iscsi csi-powerstore.dellemc.com/10.230.24.67-nfs]"
-		 return keys, nil
-	 }
-	 topologyCount, err = getTopologyCount([]string{"csi-powerstore.dellemc.com/10.230.24.67-iscsi"})
-	 assert.NoError(t, err)
-	 assert.Equal(t, 1, topologyCount)
- 
-	 // Test case: Error in FindDriverLogs
-	 FindDriverLogs = func(exe []string) (string, error) {
-		 return "", errors.New("error in FindDriverLogs")
-	 }
-	 type FindDriverLogs func(url string) string
-	 topologyCount, err = getTopologyCount([]string{})
-	 assert.Error(t, err)
-	 assert.Equal(t, 0, topologyCount)
- }
- 
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetTopologyCount(t *testing.T) {
+	// Test case: Empty topology keys
+	FindDriverLogs = func(_ []string) (string, error) {
+		return "", nil
+	}
+	topologyCount, err := getTopologyCount([]string{})
+	assert.NoError(t, err)
+	assert.Equal(t, 0, topologyCount)
+
+	// Test case: Non-empty topology keys
+
+	FindDriverLogs = func(_ []string) (string, error) {
+		var keys = "Topology Keys: [csi-powerstore.dellemc.com/10.230.24.67-iscsi csi-powerstore.dellemc.com/10.230.24.67-nfs]"
+		return keys, nil
+	}
+	topologyCount, err = getTopologyCount([]string{"csi-powerstore.dellemc.com/10.230.24.67-iscsi"})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, topologyCount)
+
+	// Test case: Error in FindDriverLogs
+	FindDriverLogs = func(_ []string) (string, error) {
+		return "", errors.New("error in FindDriverLogs")
+	}
+	type FindDriverLogs func(url string) string
+	topologyCount, err = getTopologyCount([]string{})
+	assert.Error(t, err)
+	assert.Equal(t, 0, topologyCount)
+}

--- a/pkg/testcore/suites/functional-suites_test.go
+++ b/pkg/testcore/suites/functional-suites_test.go
@@ -34,7 +34,7 @@ func TestGetTopologyCount(t *testing.T) {
 	// Test case: Non-empty topology keys
 
 	FindDriverLogs = func(_ []string) (string, error) {
-		var keys = "Topology Keys: [csi-powerstore.dellemc.com/10.230.24.67-iscsi csi-powerstore.dellemc.com/10.230.24.67-nfs]"
+		keys := "Topology Keys: [csi-powerstore.dellemc.com/10.230.24.67-iscsi csi-powerstore.dellemc.com/10.230.24.67-nfs]"
 		return keys, nil
 	}
 	topologyCount, err = getTopologyCount([]string{"csi-powerstore.dellemc.com/10.230.24.67-iscsi"})
@@ -45,7 +45,6 @@ func TestGetTopologyCount(t *testing.T) {
 	FindDriverLogs = func(_ []string) (string, error) {
 		return "", errors.New("error in FindDriverLogs")
 	}
-	type FindDriverLogs func(url string) string
 	topologyCount, err = getTopologyCount([]string{})
 	assert.Error(t, err)
 	assert.Equal(t, 0, topologyCount)

--- a/pkg/testcore/suites/functional-suites_test.go
+++ b/pkg/testcore/suites/functional-suites_test.go
@@ -34,10 +34,10 @@ func TestGetTopologyCount(t *testing.T) {
 	// Test case: Non-empty topology keys
 
 	FindDriverLogs = func(_ []string) (string, error) {
-		keys := "Topology Keys: [csi-powerstore.dellemc.com/10.230.24.67-iscsi csi-powerstore.dellemc.com/10.230.24.67-nfs]"
+		keys := "Topology Keys: [csi-powerstore.dellemc.com/1.2.3.4-iscsi csi-powerstore.dellemc.com/1.2.3.4-nfs]"
 		return keys, nil
 	}
-	topologyCount, err = getTopologyCount([]string{"csi-powerstore.dellemc.com/10.230.24.67-iscsi"})
+	topologyCount, err = getTopologyCount([]string{"csi-powerstore.dellemc.com/1.2.3.4-iscsi"})
 	assert.NoError(t, err)
 	assert.Equal(t, 1, topologyCount)
 

--- a/pkg/testcore/suites/perf-suites.go
+++ b/pkg/testcore/suites/perf-suites.go
@@ -2240,7 +2240,7 @@ type VolumeHealthMetricsSuite struct {
 }
 
 // FindDriverLogs executes command and returns the output
-func FindDriverLogs(command []string) (string, error) {
+var FindDriverLogs = func(command []string) (string, error) {
 	cmd := exec.Command(command[0], command[1:]...) // #nosec G204
 	output, err := cmd.Output()
 	if err != nil {


### PR DESCRIPTION
# Description
Customer was facing issue with running cert-csi functional test when they had multiple drivers installed. The issue with the test was that it was getting all the topologies for all drivers when it should only get the topologies for the specific driver being tested.

To resolve this, we will only get topology keys based on the ones listed in the storage class for the test.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1504 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Reproduced the user's issue by running the functional-test without the changes. Saw that topologies for all the drivers were being retrieved and test timed out.
![Screenshot (447)](https://github.com/user-attachments/assets/87d25e85-2dbf-46ba-aa86-e1742d67dc9f)

- [x] Reran the test with the changes and saw that only the topologies for the specific driver that was listed in the storage class was being retrieved. Test passed successfully
![Screenshot (446)](https://github.com/user-attachments/assets/daa7348f-a3dc-4d38-bf61-0f170df723e8)