### PR TITLE
K8s e2e - Updated K8s test binary location to use 1.32 version

### DIFF
--- a/pkg/utils/k8s_utils.go
+++ b/pkg/utils/k8s_utils.go
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+ * Copyright © 2023-2025 Dell Inc. or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,20 +49,20 @@ var (
 const (
 	// KubeConfigEnv Environmental Variable
 	KubeConfigEnv  = "KUBECONFIG"
-	k8sBinary      = "kubernetes/test/bin/e2e.test"                               // k8sBinary is the actual e2e binary that we need to execute
-	kubeconfigKey  = "-kubeconfig"                                                // kubeconfigKey  is to provide kubeconfig
-	focusStringKey = "--ginkgo.focus"                                             // focusStringKey  is to provide focus tests
-	skipStringKey  = "--ginkgo.skip"                                              // skipStringKey  is to provide skip tests
-	focusFileKey   = "--ginkgo.focus-file"                                        // focusFileKey  is to provide focus test suite
-	skipFileKey    = "--ginkgo.skip-file"                                         // focusStringKey  is to provide focus tests
-	testdriverKey  = "-storage.testdriver"                                        // testdriverKey is to provide the test driver config file
-	junitReportKey = "--ginkgo.junit-report"                                      // junitReportKey to generate the e2e report
-	timeoutKey     = "--ginkgo.timeout"                                           // timeoutKey is to provide the final
-	XML            = ".xml"                                                       // XML is an extension for .xml
-	IgnoreFile     = "pkg/utils/ignore.yaml"                                      // IgnoreFile contains the tests to be skipped
-	BinaryPrefix   = "https://storage.googleapis.com/kubernetes-release/release/" // BinaryPrefix Binary url prefix
-	BinarySuffix   = "/kubernetes-test-linux-amd64.tar.gz"                        // BinarySuffix  binary url suffix
-	BinaryFile     = "kubernetes-test-linux-amd64.tar.gz"                         // BinaryFile downloaded binary file
+	k8sBinary      = "kubernetes/test/bin/e2e.test"        // k8sBinary is the actual e2e binary that we need to execute
+	kubeconfigKey  = "-kubeconfig"                         // kubeconfigKey  is to provide kubeconfig
+	focusStringKey = "--ginkgo.focus"                      // focusStringKey  is to provide focus tests
+	skipStringKey  = "--ginkgo.skip"                       // skipStringKey  is to provide skip tests
+	focusFileKey   = "--ginkgo.focus-file"                 // focusFileKey  is to provide focus test suite
+	skipFileKey    = "--ginkgo.skip-file"                  // focusStringKey  is to provide focus tests
+	testdriverKey  = "-storage.testdriver"                 // testdriverKey is to provide the test driver config file
+	junitReportKey = "--ginkgo.junit-report"               // junitReportKey to generate the e2e report
+	timeoutKey     = "--ginkgo.timeout"                    // timeoutKey is to provide the final
+	XML            = ".xml"                                // XML is an extension for .xml
+	IgnoreFile     = "pkg/utils/ignore.yaml"               // IgnoreFile contains the tests to be skipped
+	BinaryPrefix   = "https://dl.k8s.io/"                  // BinaryPrefix Binary url prefix
+	BinarySuffix   = "/kubernetes-test-linux-amd64.tar.gz" // BinarySuffix  binary url suffix
+	BinaryFile     = "kubernetes-test-linux-amd64.tar.gz"  // BinaryFile downloaded binary file
 )
 
 // DownloadBinary will download the binary from the kubernetes artifactory based the version
@@ -153,18 +153,10 @@ func Prechecks(c *cli.Context) bool {
 
 // GetURL will return the URL by including the given version
 func GetURL(version string) (string, error) {
-	switch version {
-	case "v1.25.0":
-		return BinaryPrefix + version + BinarySuffix, nil
-	case "v1.26.0":
-		return BinaryPrefix + version + BinarySuffix, nil
-	case "v1.27.0":
-		return BinaryPrefix + version + BinarySuffix, nil
-	case "v1.28.0":
-		return BinaryPrefix + version + BinarySuffix, nil
-	default:
-		return "", errors.New("Unable to build URL with the given version:" + version)
+	if len(version) == 0 {
+		return "", errors.New("unable to build URL with the given empty version")
 	}
+	return BinaryPrefix + version + BinarySuffix, nil
 }
 
 // CheckIfBinaryExists will check the existing binary version and return true if version match else return false

--- a/pkg/utils/k8s_utils.go
+++ b/pkg/utils/k8s_utils.go
@@ -71,7 +71,7 @@ func DownloadBinary(version string) error {
 	if err != nil {
 		return err
 	}
-	log.Infof("Downloading tar file....")
+	log.Infof("Downloading tar file %s...", url)
 	client := http.Client{
 		Timeout: 20 * time.Second,
 	}

--- a/pkg/utils/k8s_utils_test.go
+++ b/pkg/utils/k8s_utils_test.go
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+ * Copyright © 2023-2025 Dell Inc. or its subsidiaries. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,8 +38,8 @@ func TestDownloadBinary(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-		{"Pass good version", args{"v1.25.0"}, false},
-		{"Pass bad version", args{"v.2.0"}, true},
+		{"Pass good version", args{"v1.32.0"}, false},
+		{"Pass bad version", args{""}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -64,7 +64,7 @@ func TestUnTarBinary(t *testing.T) {
 				os.Remove(filepath.Clean(BinaryFile))
 			}
 			if tt.name == "Untar if file present" {
-				_ = DownloadBinary("v1.25.0")
+				_ = DownloadBinary("v1.32.0")
 			}
 			if err := UnTarBinary(); (err != nil) != tt.wantErr {
 				t.Errorf("UnTarBinary() error = %v, wantErr %v", err, tt.wantErr)
@@ -161,10 +161,9 @@ func TestGetURL(t *testing.T) {
 		want    string
 		wantErr bool
 	}{
-		{"valid version27", args{"v1.27.0"}, BinaryPrefix + "v1.27.0" + BinarySuffix, false},
-		{"valid version26", args{"v1.26.0"}, BinaryPrefix + "v1.26.0" + BinarySuffix, false},
-		{"valid version25", args{"v1.25.0"}, BinaryPrefix + "v1.25.0" + BinarySuffix, false},
-		{"invalid version", args{"v1.2.0"}, "", true},
+		{"valid version30", args{"v1.30.0"}, BinaryPrefix + "v1.30.0" + BinarySuffix, false},
+		{"valid version32", args{"v1.32.0"}, BinaryPrefix + "v1.32.0" + BinarySuffix, false},
+		{"empty version", args{""}, "", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
# Description
Previous location used for K8s test binary has only up to 1.32-alpha.
Switching to new one so that we can use 1.32.0 for the K8s e2e tests.

 # GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1559 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?

```
[root@master-1-SPknwwOOoaVwH cert-csi]#  ./cert-csi k8s-e2e  --config /root/.kube/config --driver-config e2e/powerstore-config-nfs.yaml  --focus External.Storage.*  --timeout 2h --version "" --skip-tests e2e/ignore.yaml
[2025-01-14 19:08:02]  INFO Starting cert-csi; ver. 1.6.0
[2025-01-14 19:08:02]  INFO Checking file e2e/powerstore-config-nfs.yaml
[2025-01-14 19:08:02]  INFO Creating report directory: /root/reports/
[2025-01-14 19:08:02]  INFO Error wile executing version command: fork/exec kubernetes/test/bin/e2e.test: no such file or directory
[2025-01-14 19:08:02]  INFO Kuberners e2e Binary with version: not found
[2025-01-14 19:08:02] FATAL unable to build URL with the given empty version

[root@master-1-SPknwwOOoaVwH cert-csi]#  ./cert-csi k8s-e2e  --config /root/.kube/config --driver-config e2e/powerstore-config-nfs.yaml  --focus External.Storage.*  --timeout 2h --version "v1.32" --skip-tests e2e/ignore.yaml
[2025-01-14 19:08:10]  INFO Starting cert-csi; ver. 1.6.0
[2025-01-14 19:08:10]  INFO Checking file e2e/powerstore-config-nfs.yaml
[2025-01-14 19:08:10]  INFO Creating report directory: /root/reports/
[2025-01-14 19:08:10]  INFO Error wile executing version command: fork/exec kubernetes/test/bin/e2e.test: no such file or directory
[2025-01-14 19:08:10]  INFO Kuberners e2e Binary with version:v1.32 not found
[2025-01-14 19:08:10]  INFO Downloading tar file https://dl.k8s.io/v1.32/kubernetes-test-linux-amd64.tar.gz...
[2025-01-14 19:08:11] FATAL Unable to download tar file with return code :404

[root@master-1-SPknwwOOoaVwH cert-csi]#  ./cert-csi k8s-e2e  --config /root/.kube/config --driver-config e2e/powerstore-config-nfs.yaml  --focus External.Storage.*  --timeout 2h --version "v1.32.0" --skip-tests e2e/ignore.yaml
[2025-01-14 19:08:27]  INFO Starting cert-csi; ver. 1.6.0
[2025-01-14 19:08:27]  INFO Checking file e2e/powerstore-config-nfs.yaml
[2025-01-14 19:08:27]  INFO Creating report directory: /root/reports/
[2025-01-14 19:08:27]  INFO Error wile executing version command: fork/exec kubernetes/test/bin/e2e.test: no such file or directory
[2025-01-14 19:08:27]  INFO Kuberners e2e Binary with version:v1.32.0 not found
[2025-01-14 19:08:27]  INFO Downloading tar file https://dl.k8s.io/v1.32.0/kubernetes-test-linux-amd64.tar.gz...
[2025-01-14 19:08:28]  INFO Untaring...: kubernetes-test-linux-amd64.tar.gz
```

K8s E2E test for PowerMax driver has passed, with the same config that was recently run.

```
[2025-01-15 17:14:24]  INFO Starting cert-csi; ver. 1.6.0
[2025-01-15 17:14:24]  INFO Checking file /home/santhosh/csm/csi-powermax/driver-config.yaml
[2025-01-15 17:14:24]  INFO Creating report directory: /root/reports/
[2025-01-15 17:14:24]  INFO Error wile executing version command: fork/exec kubernetes/test/bin/e2e.test: no such file or directory
[2025-01-15 17:14:24]  INFO Kuberners e2e Binary with version:v1.32.0 not found
[2025-01-15 17:14:24]  INFO Downloading tar file https://dl.k8s.io/v1.32.0/kubernetes-test-linux-amd64.tar.gz...
[2025-01-15 17:14:26]  INFO Untaring...: kubernetes-test-linux-amd64.tar.gz
[2025-01-15 17:14:29]  INFO kubernetes/
kubernetes/test/
kubernetes/test/bin/
kubernetes/test/bin/go-runner
kubernetes/test/bin/e2e.test
kubernetes/test/bin/kubemark
kubernetes/test/bin/e2e_node.test
kubernetes/test/bin/ginkgo
.....
PASS
Generating Report:
TestSuite Name: Kubernetes e2e suite
Total Tests Executed: 63
Total Tests Passed: 63
Total Tests Failed: 0
```

CSM [cert-csi doc](https://dell.github.io/csm-docs/docs/support/cert-csi/#kubernetes-end-to-end-tests) points out the version format to use. Log is also updated to print the URL that's failing.