### PR TITLE
Extended time for pod operations to allow for API Calls to check if metrics data exists

### DIFF
--- a/pkg/testcore/suites/perf-suites.go
+++ b/pkg/testcore/suites/perf-suites.go
@@ -1098,7 +1098,7 @@ func (vis *VolumeIoSuite) Run(ctx context.Context, storageClass string, clients 
 					}
 				}
 				ddRes := bytes.NewBufferString("")
-				if err := podClient.Exec(ctx, writerPod.Object, []string{"/bin/bash", "-c", "dd if=/dev/urandom bs=1M count=128 oflag=sync > " + file}, ddRes, os.Stderr, false); err != nil {
+				if err := podClient.Exec(ctx, writerPod.Object, []string{"/bin/bash", "-c", "dd if=/dev/urandom bs=1M count=1280 oflag=sync > " + file}, ddRes, os.Stderr, false); err != nil {
 					log.Info(err)
 					return err
 				}
@@ -1107,6 +1107,9 @@ func (vis *VolumeIoSuite) Run(ctx context.Context, storageClass string, clients 
 				if err := podClient.Exec(ctx, writerPod.Object, []string{"/bin/bash", "-c", "sha512sum " + file + " > " + sum}, os.Stdout, os.Stderr, false); err != nil {
 					return err
 				}
+
+				time.Sleep(300 * time.Millisecond)
+
 				podClient.Delete(ctx, writerPod.Object).Sync(errCtx)
 				if writerPod.HasError() {
 					return writerPod.GetError()


### PR DESCRIPTION
# Description

Background:

When running the Karavi-Testing test to check for existence of metrics data, there was a timing issue with PowerMax's API Performance. The sequence of steps is Karavi-Testing is calling the Cert-CSI's VolumeIO Run function through executing the Cert-CSI binary. VolumeIO's Run function will create a pod in the background process while Karavi-Testing's metrics_util.go file logic will continue down to the next line of code, which would be a select statement to detect which goroutine will occur first. However, by the time the select statement is reached, the pod is already deleted, and the background process is finished.

Therefore, this PR will extend the time for pod operations to prolong the lifespan of the pod which will allow it to exist when the API Call checks if metrics data exists.

(https://jira.cec.lab.emc.com/browse/ECS01B-301)

I also updated this Confluence Page for the EXPORT Environment Variables that I used to run the Karavi-Testing:

[How to run the observability E2E testing - Container Storage Modules - ISG Confluence (internal)](https://confluence.cec.lab.emc.com/display/CSIECO/How+to+run+the+observability+E2E+testing)

# Checklist:

- [X ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [X ] I have commented my code, particularly in hard-to-understand areas
- [X ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?

![image](https://github.com/user-attachments/assets/4757b260-5a0f-4ee7-8012-b0e1e522a21e)
